### PR TITLE
Show clear filter button

### DIFF
--- a/src/Table/Table.stories.js
+++ b/src/Table/Table.stories.js
@@ -222,8 +222,10 @@ export const main = () => {
           return `(entity_id eq '123')`;
         }}
         withFilter={[
-          { label: 'Guys', facetKey: 'guys', excludeable: true },
-          { label: 'Pankaka', facetKey: 'pankaka', excludeable: false },
+          {
+            label: 'Guys', facetKey: 'guys', multiSelect: false, defaultSelect: 'Mike(1133)',
+          },
+          { label: 'Pankaka', facetKey: 'pankaka' },
         ]}
         withSort={[
           { value: 'created', label: 'Created' },
@@ -397,8 +399,8 @@ export const controlls = () => {
         tableHook={hook}
         withSearch={boolean('With search', true)}
         withFilter={[
-          { label: 'Gurka', facetKey: 'gurka', excludeable: true },
-          { label: 'Pankaka', facetKey: 'pankaka', excludeable: false },
+          { label: 'Gurka', facetKey: 'gurka' },
+          { label: 'Pankaka', facetKey: 'pankaka' },
         ]}
         withSort={[
           { value: 'created', label: 'Created' },
@@ -493,8 +495,8 @@ export const separate = () => {
           return null;
         }}
         withFilter={[
-          { label: 'Guys', facetKey: 'guys', excludeable: true },
-          { label: 'Pankaka', facetKey: 'pankaka', excludeable: false },
+          { label: 'Guys', facetKey: 'guys' },
+          { label: 'Pankaka', facetKey: 'pankaka' },
         ]}
         withSort={[
           { value: 'created', label: 'Created' },

--- a/src/Table/TableFilter/useFilterHook.js
+++ b/src/Table/TableFilter/useFilterHook.js
@@ -14,6 +14,7 @@ const useFilterProvider = (filterKeys, tableHook, parser) => {
 
   const [filterGroups] = useState(filterKeys);
   const [selectedItems, setSelectedItems] = useState({});
+  const [hasSelectedItems, setHasSelectedItems] = useState(false);
 
 
   // Initial setter. This will trigger Poppulate effect as well.
@@ -78,6 +79,18 @@ const useFilterProvider = (filterKeys, tableHook, parser) => {
         setIsDirty(true);
       }
     }
+
+    const hasSelected = Object.keys(selectedItems).some((key) => {
+      const list = selectedItems[key];
+      const category = filterKeys.find(({ facetKey }) => facetKey === key);
+
+      // Look if there is items in the selected group
+      // But dont include if its not a multiselect (aka singleSelect) filter.
+      // Since a singleSelect MUST have a value, it cant be cleared.
+      return (list.length > 0) && category.multiSelect !== false;
+    });
+
+    setHasSelectedItems(hasSelected);
   }, [isReady, selectedItems]);
 
 
@@ -87,10 +100,7 @@ const useFilterProvider = (filterKeys, tableHook, parser) => {
     getSelectedItems: () => selectedItems,
     getSelectedItemsByKey: (groupKey) => selectedItems[groupKey],
     getFilterGroups: () => filterGroups,
-    hasActiveFilter: () => Object.values(selectedItems)
-      .some((list) => (
-        list.length > 0
-        && list.some(({ isMultiSelect }) => isMultiSelect))),
+    hasActiveFilter: () => hasSelectedItems,
     setSelectedItems: (state) => setSelectedItems(state),
     clearFilter: () => {
       const categoryDefaultValues = filterKeys.filter(({ defaultSelect }) => defaultSelect);


### PR DESCRIPTION
# Description

When the filter read its state from the url, eg after reloading the page, the table component lost some of its state and the `clear filter` button wouldn't show up until you altered the table-filter-state again.

Fixes https://github.com/asurgent/admin/issues/823

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Run storybook, go to `Table/Main` story.
- Set a filter & make sure the `clear filter` button appears.
- Reload page.
- The `clear filter` button should still be there.
- Now clear the filter by clicking the button.
- Open the `Guys` filter and make sure an option is selected, even tough the clear filter button is not visible. This is the correct behaviour for a single-select filter-category.

# Author checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have implemented the changes/component in Storybook

# Reviewer checklist:

- [x] The code runs without errors and/or warnings
- [x] The code followsthe style guidelines of this project
- [x] The documentation is sufficinent 
- [x] The tests runs withour errors and covers all/most states/scenarios
- [x] The component/changes are represented in storybook
