### PR TITLE
Make a new loader component, prepare for removing the old one.

### DIFF
--- a/src/Loader/Loader.js
+++ b/src/Loader/Loader.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as C from './Loader.styled';
+
+const propTypes = {
+  size: PropTypes.number,
+  color: PropTypes.string,
+  speed: PropTypes.number,
+};
+
+const defaultProps = {
+  size: 15,
+  color: 'black',
+  speed: 2,
+};
+
+const Loader = ({ size, color, speed }) => (
+  <>
+    <C.Wrapper size={size}>
+      <C.Ring size={size} color={color} speed={speed} />
+    </C.Wrapper>
+  </>
+);
+
+Loader.propTypes = propTypes;
+Loader.defaultProps = defaultProps;
+
+export default Loader;

--- a/src/Loader/Loader.js
+++ b/src/Loader/Loader.js
@@ -14,13 +14,9 @@ const defaultProps = {
   speed: 2,
 };
 
-const Loader = ({ size, color, speed }) => (
-  <>
-    <C.Wrapper size={size}>
-      <C.Ring size={size} color={color} speed={speed} />
-    </C.Wrapper>
-  </>
-);
+const Loader = ({
+  size, color, speed,
+}) => (<C.Ring size={size} color={color} speed={speed} />);
 
 Loader.propTypes = propTypes;
 Loader.defaultProps = defaultProps;

--- a/src/Loader/Loader.stories.js
+++ b/src/Loader/Loader.stories.js
@@ -9,3 +9,7 @@ export default { title: 'UI Components|Loader', decorators: [withKnobs] };
 export const loader = () => (
   <Loader.Ring size={number('Size', 100)} color={text('Color', '#239dd9')} />
 );
+
+loader.story = {
+  name: 'Ring Loader',
+};

--- a/src/Loader/Loader.stories.js
+++ b/src/Loader/Loader.stories.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import {
+  withKnobs, number, text,
+} from '@storybook/addon-knobs';
+import * as Loader from './index';
+
+export default { title: 'UI Components|Loader', decorators: [withKnobs] };
+
+export const loader = () => (
+  <Loader.Ring size={number('Size', 100)} color={text('Color', '#239dd9')} />
+);

--- a/src/Loader/Loader.stories.js
+++ b/src/Loader/Loader.stories.js
@@ -7,7 +7,7 @@ import * as Loader from './index';
 export default { title: 'UI Components|Loader', decorators: [withKnobs] };
 
 export const loader = () => (
-  <Loader.Ring size={number('Size', 100)} color={text('Color', '#239dd9')} />
+  <Loader.Ring size={number('Size', 100)} speed={number('Speed', 2)} color={text('Color', '#239dd9')} />
 );
 
 loader.story = {

--- a/src/Loader/Loader.styled.js
+++ b/src/Loader/Loader.styled.js
@@ -1,0 +1,63 @@
+import styled, { keyframes } from 'styled-components';
+
+const animAfter = ({ color, size }) => keyframes`
+    0%,
+    50% {
+        border: 0px solid ${color};
+        opacity: 0.1;
+    }
+    100% {
+        border: ${size / 10}px solid ${color};
+        opacity: 1;
+    }
+`;
+
+const animBefore = ({ color, size }) => keyframes`
+    0% {
+        border: ${size / 10}px solid ${color};
+        opacity: 1;
+    }
+    50%,
+    100% {
+        border: 0px solid ${color};
+        opacity: 0.1;
+    }
+`;
+
+const Wrapper = styled.div`
+  width: ${({ size }) => `${size}px`};
+  height: ${({ size }) => `${size}px`};
+`;
+
+const Ring = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  &:after,
+  &:before {
+    width: 100%;
+    height: 100%;
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+    animation-timing-function: ease-in-out;
+    box-sizing: border-box;
+    border: ${({ size, color }) => `${size / 10}px solid ${color}`};
+  }
+  &:before {
+    border: ${({ size, color }) => `${size / 10}px solid ${color}`};
+    animation-name: ${animBefore};
+  }
+  &:after {
+    border: ${({ color }) => `0px solid ${color}`};
+    animation-name: ${animAfter};
+  }
+`;
+
+export { Wrapper, Ring };

--- a/src/Loader/Loader.styled.js
+++ b/src/Loader/Loader.styled.js
@@ -1,63 +1,36 @@
 import styled, { keyframes } from 'styled-components';
 
-const animAfter = ({ color, size }) => keyframes`
-    0%,
-    50% {
-        border: 0px solid ${color};
-        opacity: 0.1;
-    }
-    100% {
-        border: ${size / 10}px solid ${color};
-        opacity: 1;
-    }
-`;
-
-const animBefore = ({ color, size }) => keyframes`
-    0% {
-        border: ${size / 10}px solid ${color};
-        opacity: 1;
-    }
-    50%,
-    100% {
-        border: 0px solid ${color};
-        opacity: 0.1;
-    }
-`;
-
-const Wrapper = styled.div`
-  width: ${({ size }) => `${size}px`};
-  height: ${({ size }) => `${size}px`};
+const ringAnim = ({ size }) => keyframes`
+  0% {
+    clip-path: circle(${size / 2}px);
+    opacity: 1;
+  }
+  30% {
+    opacity: 0;
+  }
+  50% {
+    clip-path: circle(${size / 2 - (size / 10)}px);
+    opacity: 0;
+  }
+  100% {
+    clip-path: circle(${size / 2}px);
+    opacity: 1;
+  }
 `;
 
 const Ring = styled.div`
-  position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  max-width: 100%;
-  height: 100%;
-  &:after,
-  &:before {
-    width: 100%;
-    height: 100%;
-    content: "";
-    position: absolute;
-    border-radius: 50%;
-    animation-duration: 2s;
-    animation-iteration-count: infinite;
-    animation-timing-function: ease-in-out;
-    box-sizing: border-box;
-    border: ${({ size, color }) => `${size / 10}px solid ${color}`};
-  }
-  &:before {
-    border: ${({ size, color }) => `${size / 10}px solid ${color}`};
-    animation-name: ${animBefore};
-  }
-  &:after {
-    border: ${({ color }) => `0px solid ${color}`};
-    animation-name: ${animAfter};
-  }
+  box-sizing: border-box;
+  height: ${({ size }) => `${size}px`};
+  width: ${({ size }) => `${size}px`};
+  background: transparent;
+  border-radius: 50%;
+  border: ${({ size, color }) => `${size / 10}px solid ${color}`} ;
+  border-radius: 50%;
+  animation-duration: ${({ speed }) => `${speed}s`};
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: ${ringAnim};
+  clip-path: circle((size / 2) + "px");
 `;
 
-export { Wrapper, Ring };
+export { Ring };

--- a/src/Loader/index.js
+++ b/src/Loader/index.js
@@ -1,3 +1,1 @@
-import Loader from './Loader';
-
-export { Loader as Ring };
+export { default as Ring } from './Loader';

--- a/src/Loader/index.js
+++ b/src/Loader/index.js
@@ -1,0 +1,3 @@
+import Loader from './Loader';
+
+export { Loader as Ring };

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import * as Table from './Table';
 import * as Tag from './Tag';
 
 import * as Button from './Button';
+import * as Loader from './Loader';
 import * as Block from './Block';
 import * as Modal from './Modal';
 import * as Switch from './Switch';
@@ -18,6 +19,7 @@ import * as Omnibar from './layout/Omnibar';
 
 export {
   Button,
+  Loader,
   Block,
   Form,
   Modal,


### PR DESCRIPTION
# Description

The React-Spinners-Kit that we use for our loader-component is using animation with box-shadow and the inset property, which is not working as it should on Safari (a lot of flickering). So instead we created our own component that animates a clip-path instead. After this we can remove the old one and replace all uses of that one with this one.

Fixes https://github.com/asurgent/admin/issues/839
Relates to https://github.com/asurgent/admin/issues/830

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] Go to Storybook, then Loader -> Ring Loader and verify that it works on different sizes & Chrome/Safari/Firefox

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
