### PR TITLE
radio group fix

### DIFF
--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -65,6 +65,16 @@ export const defaultForm = () => {
         { label: 'label2', value: 'value2' },
       ],
     },
+    someRadioGroup2: {
+      type: 'radiogroup',
+      label: 'Some Radio Group2',
+      noLabel: false,
+      options: [
+        { label: 'label1', value: 'value1' },
+        { label: 'label2', value: 'value2' },
+      ],
+      tooltip: 'tooltip',
+    },
     someSelect: {
       type: 'select',
       label: 'Some Select',
@@ -80,7 +90,8 @@ export const defaultForm = () => {
   useEffect(() => {
     formData.updateFields([
       { name: 'someText', value: 'Good bye' },
-      { name: 'someRadioGroup', value: 'value2' },
+      { name: 'someRadioGroup', value: 'value1' },
+      { name: 'someRadioGroup2', value: 'value1' },
       { name: 'someSelect', value: '3' },
       { name: 'someDate', value: moment().format('YYYY-MM-DD') },
     ]);

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -67,11 +67,10 @@ export const defaultForm = () => {
     },
     someRadioGroup2: {
       type: 'radiogroup',
-      label: 'Some Radio Group2',
-      noLabel: false,
+      label: 'Some Radio Group',
       options: [
-        { label: 'label1', value: 'value1' },
-        { label: 'label2', value: 'value2' },
+        { label: 'label3', value: 'value3' },
+        { label: 'label4', value: 'value4' },
       ],
       tooltip: 'tooltip',
     },
@@ -93,7 +92,7 @@ export const defaultForm = () => {
     formData.updateFields([
       { name: 'someText', value: 'Good bye' },
       { name: 'someRadioGroup', value: 'value1' },
-      { name: 'someRadioGroup2', value: 'value1' },
+      { name: 'someRadioGroup2', value: 'value4' },
       { name: 'someSelect', value: '3' },
       { name: 'someDate', value: moment().format('YYYY-MM-DD') },
     ]);

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -79,11 +79,13 @@ export const defaultForm = () => {
       type: 'select',
       label: 'Some Select',
       options: [{ value: '1', label: 'First option', default: true }, { value: '2', label: 'Second option' }, { value: '3', label: 'Third option' }],
+      tooltip: 'tooltip',
     },
     someDate: {
       type: 'datepicker',
       options: [],
       render: (spec) => spec.someText.length < 10,
+      tooltip: 'tooltip',
     },
   });
 

--- a/src/Form/types/DatePicker.js
+++ b/src/Form/types/DatePicker.js
@@ -9,7 +9,7 @@ import * as C from './DatePicker.styled';
 import {
   Label,
   Header,
-  Icon,
+  TooltipIcon,
 } from './Text.styled';
 import * as Tooltip from '../../Tooltip';
 
@@ -39,7 +39,7 @@ const DatePicker = forwardRef((props, ref) => {
           <Label>{label || name}</Label>
           { tooltip && (
           <Tooltip.Middle tip={tooltip}>
-            <Icon className="far fa-question-circle" />
+            <TooltipIcon />
           </Tooltip.Middle>
           )}
         </Header>

--- a/src/Form/types/Label.js
+++ b/src/Form/types/Label.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import * as Tooltip from '../../Tooltip';
 
 import {
-  Icon,
+  TooltipIcon,
   Main,
   Label as InputLabel,
   Header,
@@ -46,7 +46,7 @@ const Label = (props) => {
         <InputLabel>{label || name}</InputLabel>
         { tooltip && (
         <Tooltip.Middle tip={tooltip}>
-          <Icon className="far fa-question-circle" />
+          <TooltipIcon />
         </Tooltip.Middle>
         )}
       </Header>

--- a/src/Form/types/RadioGroup.js
+++ b/src/Form/types/RadioGroup.js
@@ -7,9 +7,8 @@ import * as Tooltip from '../../Tooltip';
 
 const propTypes = {
   value: PropTypes.string,
-  // label is required since it serves as an ID
-  label: PropTypes.string.isRequired,
-  noLabel: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.instanceOf(Object)),
   wrapRadios: PropTypes.bool,
   tooltip: PropTypes.string,
@@ -17,7 +16,7 @@ const propTypes = {
 
 const defaultProps = {
   value: '',
-  noLabel: false,
+  label: '',
   options: [],
   wrapRadios: false,
   tooltip: '',
@@ -25,7 +24,7 @@ const defaultProps = {
 
 const RadioGroup = forwardRef((props, ref) => {
   const {
-    value, label, noLabel, tooltip, options, wrapRadios,
+    name, value, label, tooltip, options, wrapRadios,
   } = props;
   const [val, setVal] = useState(null);
 
@@ -35,7 +34,7 @@ const RadioGroup = forwardRef((props, ref) => {
 
   return (
     <>
-      {noLabel === false && (
+      {label && (
       <C.Header>
         <C.Label>{label}</C.Label>
         { tooltip && (
@@ -48,10 +47,10 @@ const RadioGroup = forwardRef((props, ref) => {
 
       <C.RadioWrapper wrapRadios={wrapRadios}>
         {options.map((opt) => (
-          <C.Label key={label + opt.label}>
+          <C.Label key={opt.label || opt.value}>
             <C.RadioInput
               type="radio"
-              name={`${label}-${opt.label}`}
+              name={name}
               value={opt.value}
               checked={val === opt.value}
               onChange={() => setVal(opt.value)}

--- a/src/Form/types/RadioGroup.js
+++ b/src/Form/types/RadioGroup.js
@@ -2,6 +2,7 @@
 import React, { forwardRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as C from './RadioGroup.styled';
+import { TooltipIcon } from './Text.styled';
 import * as Tooltip from '../../Tooltip';
 
 const propTypes = {
@@ -39,7 +40,7 @@ const RadioGroup = forwardRef((props, ref) => {
         <C.Label>{label}</C.Label>
         { tooltip && (
         <Tooltip.Middle tip={tooltip}>
-          <C.Icon className="far fa-question-circle" />
+          <TooltipIcon />
         </Tooltip.Middle>
         )}
       </C.Header>

--- a/src/Form/types/RadioGroup.js
+++ b/src/Form/types/RadioGroup.js
@@ -2,75 +2,67 @@
 import React, { forwardRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as C from './RadioGroup.styled';
-
-const radioPropTypes = {
-  label: PropTypes.string,
-  checked: PropTypes.bool,
-  onChange: PropTypes.func,
-};
-
-const radioDefaultProps = {
-  label: '',
-  checked: false,
-  onChange: () => {},
-};
-
-
-const Radio = ({ label, checked, onChange }) => (
-  <C.Label>
-    <C.RadioInput
-      type="radio"
-      name={label}
-      value={label}
-      checked={checked}
-      onChange={onChange}
-    />
-    <C.CheckMark />
-    <C.Text>{label}</C.Text>
-  </C.Label>
-);
-
-Radio.propTypes = radioPropTypes;
-Radio.defaultProps = radioDefaultProps;
+import * as Tooltip from '../../Tooltip';
 
 const propTypes = {
   value: PropTypes.string,
+  // label is required since it serves as an ID
+  label: PropTypes.string.isRequired,
+  noLabel: PropTypes.bool,
   options: PropTypes.arrayOf(PropTypes.instanceOf(Object)),
   wrapRadios: PropTypes.bool,
+  tooltip: PropTypes.string,
 };
 
 const defaultProps = {
   value: '',
+  noLabel: false,
   options: [],
   wrapRadios: false,
+  tooltip: '',
 };
 
 const RadioGroup = forwardRef((props, ref) => {
-  const { value, options, wrapRadios } = props;
+  const {
+    value, label, noLabel, tooltip, options, wrapRadios,
+  } = props;
   const [val, setVal] = useState(null);
 
   useEffect(() => {
     setVal(value || '');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   return (
-    <C.RadioWrapper wrapRadios={wrapRadios}>
-      {options.map((opt, ind) => (
-        <C.Label key={opt.label || `radio-${ind}`}>
-          <C.RadioInput
-            type="radio"
-            name={opt.label}
-            value={opt.value}
-            checked={val === opt.value}
-            onChange={() => setVal(opt.value)}
-            ref={val === opt.value ? ref : null}
-          />
-          <C.CheckMark />
-          <C.Text>{opt.label}</C.Text>
-        </C.Label>
-      ))}
-    </C.RadioWrapper>
+    <>
+      {noLabel === false && (
+      <C.Header>
+        <C.Label>{label}</C.Label>
+        { tooltip && (
+        <Tooltip.Middle tip={tooltip}>
+          <C.Icon className="far fa-question-circle" />
+        </Tooltip.Middle>
+        )}
+      </C.Header>
+      )}
+
+      <C.RadioWrapper wrapRadios={wrapRadios}>
+        {options.map((opt) => (
+          <C.Label key={label + opt.label}>
+            <C.RadioInput
+              type="radio"
+              name={`${label}-${opt.label}`}
+              value={opt.value}
+              checked={val === opt.value}
+              onChange={() => setVal(opt.value)}
+              ref={val === opt.value ? ref : null}
+            />
+            <C.CheckMark />
+            <C.Text>{opt.label}</C.Text>
+          </C.Label>
+        ))}
+
+      </C.RadioWrapper>
+    </>
   );
 });
 

--- a/src/Form/types/RadioGroup.styled.js
+++ b/src/Form/types/RadioGroup.styled.js
@@ -1,19 +1,37 @@
 import styled from 'styled-components';
 
-export const RadioWrapper = styled.div`
-    display: flex;
-    flex-direction: ${({ wrapRadios }) => (wrapRadios === true ? 'column' : 'row')};
-    align-items: flex-start;
-`;
 
 export const Label = styled.label`
     display: flex;
     position: relative;
-    justify-content: center;
-    margin: 1.6rem;
-    &:not(:first-child) {
+    align-items: center;
+    font-size: 1.4rem;
+    letter-spacing: .1rem;
+    color: ${({ theme }) => theme.gray700};
+    text-transform: capitalize;
+`;
+
+export const RadioWrapper = styled.div`
+    display: flex;
+    flex-direction: ${({ wrapRadios }) => (wrapRadios === true ? 'column' : 'row')};
+    align-items: flex-start;
+
+    ${Label}:not(:first-child) {
         margin-left: 1.6rem;
     }
+`;
+
+export const Icon = styled.i`
+  width: 1.6rem;
+  text-align: right;
+  color: ${({ theme }) => theme.gray700};
+  cursor: pointer;
+`;
+
+export const Header = styled.div`
+  margin-bottom: .8rem;
+  display: flex;
+  justify-content: space-between;
 `;
 
 export const CheckMark = styled.span`

--- a/src/Form/types/Select.js
+++ b/src/Form/types/Select.js
@@ -5,7 +5,7 @@ import * as Tooltip from '../../Tooltip';
 
 import {
   Main,
-  Icon,
+  TooltipIcon,
   Label,
   Header,
   SelectWrapper,
@@ -72,7 +72,7 @@ const Select = forwardRef((props, ref) => {
           <Label>{label || name}</Label>
           { tooltip && (
           <Tooltip.Middle tip={tooltip}>
-            <Icon className="far fa-question-circle" />
+            <TooltipIcon />
           </Tooltip.Middle>
           )}
         </Header>

--- a/src/Form/types/Text.js
+++ b/src/Form/types/Text.js
@@ -7,8 +7,9 @@ import {
   Wrapper,
   Label,
   Header,
-  Icon,
+  TooltipIcon,
 } from './Text.styled';
+
 
 const propTyps = {
   value: PropTypes.string,
@@ -49,7 +50,7 @@ const Text = forwardRef((props, ref) => {
           <Label>{label || name}</Label>
           { tooltip && (
           <Tooltip.Middle tip={tooltip}>
-            <Icon className="far fa-question-circle" />
+            <TooltipIcon />
           </Tooltip.Middle>
           )}
         </Header>

--- a/src/Form/types/Text.styled.js
+++ b/src/Form/types/Text.styled.js
@@ -1,5 +1,6 @@
 
 import styled from 'styled-components';
+import HelpOutline from '@material-ui/icons/HelpOutline';
 
 export const Main = styled.div`
   width: 100%;
@@ -57,9 +58,7 @@ export const Header = styled.div`
   display: flex;
 `;
 
-export const Icon = styled.i`
-  width: 1.6rem;
-  text-align: right;
+export const TooltipIcon = styled(HelpOutline)`
   color: ${({ theme }) => theme.gray700};
   cursor: pointer;
 `;

--- a/src/Form/types/TextArea.js
+++ b/src/Form/types/TextArea.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import * as Tooltip from '../../Tooltip';
 
 import {
-  Main, Wrapper, Label, Header, Icon,
+  Main, Wrapper, Label, Header, TooltipIcon,
 } from './Text.styled';
 
 const propTyps = {
@@ -45,7 +45,7 @@ const TextArea = forwardRef((props, ref) => {
           <Label>{label || name}</Label>
           { tooltip && (
           <Tooltip.Middle tip={tooltip}>
-            <Icon className="far fa-question-circle" />
+            <TooltipIcon />
           </Tooltip.Middle>
           )}
         </Header>


### PR DESCRIPTION
# Description

Radiogroup had a bug in that it could not differentiate between two radiogroups if they both had the same options (since it leads to the inputs having the same name). Fix for that. Also added a header similar to other input types.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Go to Form -> Default form and see that you can toggle the radiogroups independently

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
