### PR TITLE
Form isDirty as state

### DIFF
--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -81,18 +81,20 @@ const Form = (props) => {
 
   const { inputFileds } = hook;
 
-  const eventTrigger = (name, timerAction, action) => {
+  const eventTrigger = (name, timerAction, action, reRender = false) => {
     setTimeout(() => {
       const { values, dirty, dirtyItems } = hook.getValues();
       setIsDirty(dirty);
-      hook.renderItems(values);
-
+      if (reRender) {
+        hook.renderItems(values);
+      }
       if (timerAction) {
         timerAction(values, dirty, dirtyItems);
       }
       action(values, dirty, dirtyItems, name);
     }, 0);
   };
+
   const onSubmitAction = () => {
     eventTrigger(null, null, onSubmit);
   };
@@ -122,7 +124,9 @@ const Form = (props) => {
       }}
       onChange={(event) => {
         const { name } = event.target;
-        eventTrigger(name, changeTimer, onChange);
+        // Will trigger a rerender of form based on
+        // input field render property
+        eventTrigger(name, changeTimer, onChange, true);
       }}
       onSubmit={(event) => {
         event.preventDefault();

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -152,7 +152,7 @@ export const defaultForm = () => {
             <Block.SpaceBetween>
               <Button.Hollow>Cancel</Button.Hollow>
               <Button.Secondary
-                disabled={!isDirty()}
+                disabled={!isDirty}
                 onClick={onResetAction}
               >
                 Reset


### PR DESCRIPTION
# Description

Return `isDirty` as a state in child-render instead of object, since that wont trigger a redraw

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Run `Form - Default form` storybook
- Change from data
- Reset-button should toggle between disabled and enabled when clicked/form-change

# Author checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [x] The code runs without errors and/or warnings
- [x] The code followsthe style guidelines of this project
- [x] The documentation is sufficinent 
- [x] The tests runs withour errors and covers all/most states/scenarios
- [x] The component/changes are represented in storybook
