### PR TITLE
Cron: Start & End date fix

### DIFF
--- a/src/Cron/CronEditor.js
+++ b/src/Cron/CronEditor.js
@@ -61,7 +61,7 @@ const CronEditor = ({
           }
         </ThemeProvider>
       </C.Editor>
-      { hook.willRunMoreThanOnce() && (
+      { hook.willRunMoreThanOnce() && hook.getStartDate() && (
         <RepeatOutput
           withBorder
           startDate={hook.getStartDate()}

--- a/src/Cron/CronEditor.styled.js
+++ b/src/Cron/CronEditor.styled.js
@@ -11,6 +11,11 @@ export const Row = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr;
     align-items: flex-end;
+
+    .MuiFormHelperText-root.Mui-error.MuiFormHelperText-filled {
+        position: absolute;
+        bottom: -2rem;
+    }
 `;
 
 export const Label = styled.div`

--- a/src/Cron/components/Occurrence.js
+++ b/src/Cron/components/Occurrence.js
@@ -41,6 +41,7 @@ const Occurrence = ({ hook }) => (
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <KeyboardDatePicker
           format="DD-MM-YYYY"
+          minDate={hook.getStartDate()}
           value={hook.getEndDate()}
           onChange={hook.handleEndDateChange}
           KeyboardButtonProps={{

--- a/src/Cron/useCronHook.js
+++ b/src/Cron/useCronHook.js
@@ -213,7 +213,7 @@ const useFormBuilder = ({
       setDuration(parsed);
     },
     handleStartDateChange: (date) => {
-      if (date) {
+      if (date && date.isValid()) {
         setStartDate(date.local());
         if (date >= endDate) {
           setEndDate(date.local());
@@ -223,9 +223,11 @@ const useFormBuilder = ({
       }
     },
     handleEndDateChange: (date) => {
-      if (date) {
-        if (date >= startDate) {
+      if (date && date.isValid()) {
+        if (date.isAfter(startDate)) {
           setEndDate(date.local());
+        } else {
+          setEndDate(startDate.local());
         }
       } else {
         setEndDate(date);

--- a/src/Cron/useCronHook.js
+++ b/src/Cron/useCronHook.js
@@ -64,9 +64,12 @@ const useFormBuilder = ({
   }, []);
 
   useEffect(() => {
-    if (occurrence === OCCURRENCES_UNTILL_DATE) {
+    if (occurrence === OCCURRENCES_UNTILL_DATE
+      && moment(startDate).isValid()
+      && moment(endDate).isValid()) {
       const newEnd = moment(endDate);
       const durationEnd = moment(startDate).add(duration, durationType);
+
       if (durationEnd > newEnd) {
         durationEnd.second(59);
         durationEnd.minutes(59);
@@ -80,20 +83,23 @@ const useFormBuilder = ({
       }
     } else if (occurrence === OCCURRENCES_FOREVER) {
       setEndDate(moment('9999-12-30 23:39:59').local());
-    } else {
+    } else if (moment(startDate).isValid()) {
       const newEnd = moment(startDate).add(duration, durationType);
       setEndDate(newEnd.local());
+    } else {
+      setEndDate(null);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [occurrence, startDate, durationType, duration]);
 
   useEffect(() => {
-    const hours = startDate.hours();
-    const minutes = startDate.minutes();
-    const weekday = startDate.weekday();
-    const dayOfMonth = startDate.date();
-
-    if (occurrence !== OCCURRENCES_ONCE) {
+    if (occurrence !== OCCURRENCES_ONCE
+      && startDate
+      && moment(startDate).isValid()) {
+      const hours = startDate.hours();
+      const minutes = startDate.minutes();
+      const weekday = startDate.weekday();
+      const dayOfMonth = startDate.date();
       if (repeatType === REPEAT_DAY) {
         setCronExpression(`${minutes} ${hours} * * *`);
       } else if (repeatType === REPEAT_WEEK) {
@@ -111,8 +117,10 @@ const useFormBuilder = ({
 
   useEffect(() => {
     if (isReady) {
+      const validDates = (moment(startDate).isValid() && moment(endDate).isValid());
+
       const payload = {
-        valid: true,
+        valid: validDates,
         payload: {
           start: moment(startDate).utc().toISOString(),
           end: moment(endDate).utc().toISOString(),
@@ -129,7 +137,7 @@ const useFormBuilder = ({
 
       if (occurrence !== OCCURRENCES_ONCE) {
         Object.assign(payload, {
-          valid: Boolean(validateToString(cronExpression)),
+          valid: Boolean(validateToString(cronExpression)) && validDates,
           repeatType,
         });
 


### PR DESCRIPTION

# Description

Handle the use case when the user empties the input-filed for start & end -date. This is currently causing fatal crash

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Run storybook for `Cron`
- Empty start-date field
- Select end on date and empty that as well
- Try different combinations
- Payload should return `valid: false`

# Author checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- X ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [x] The code runs without errors and/or warnings
- [x] The code followsthe style guidelines of this project
- [x] The documentation is sufficinent 
- [x] The tests runs withour errors and covers all/most states/scenarios
- [x] The component/changes are represented in storybook
