### PR TITLE
Form error-list & translation fixes

### DIFF
--- a/.storybook/decorators/i18nDecorator.js
+++ b/.storybook/decorators/i18nDecorator.js
@@ -11,6 +11,7 @@ i18n
       resources,
       lng: 'sv',
       fallbackLng: 'sv',
+      defaultNS: 'asurgentui',
       whitelist: ['en', 'sv'],
       interpolation: {
         escapeValue: false,

--- a/lib/i18n/addTranslation.js
+++ b/lib/i18n/addTranslation.js
@@ -1,7 +1,7 @@
 import i18next from 'i18next';
 
 const contract = (translation) => {
-  const translationMapper = (key, namespace) => i18next.t(`${namespace ? `${namespace}:` : ''}${translation.id}_${key}`);
+  const translationMapper = (key, namespace) => i18next.t(`${namespace ? `${namespace}:` : ''}${translation.id}${key}`);
 
   return {
     translation,

--- a/lib/i18n/findTranslations.js
+++ b/lib/i18n/findTranslations.js
@@ -9,7 +9,7 @@ const findTranslations = (context, resourceKey) => {
 
   const buildTranslation = (t, id) => Object.keys(t)
     .reduce((acc, item) => Object.assign(acc, {
-      [`${id}_${item}`]: t[item],
+      [`${id}${item}`]: t[item],
     }), {});
 
   const moduleTranslations = modules.reduce((acc, { default: mod }) => {

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -76,6 +76,11 @@ const Form = (props) => {
         },
       });
     }
+
+    // Empty errors list on unmount
+    return () => {
+      hook.errors([]);
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -7,7 +7,7 @@ import moment from 'moment';
 import * as Form from './index';
 import * as Button from '../Button';
 import * as Block from '../Block';
-import './Formstories.translation';
+import translation from './Formstories.translation';
 
 export default {
   title: 'UI Components|Form',
@@ -118,12 +118,12 @@ export const defaultForm = () => {
   useEffect(() => {
     if (renderErrors) {
       formData.errors([
-        { property: 'someText', message: 'You need some text', message_translation_key: 'asurgentui:FormStory_one' },
-        { property: 'someRadioGroup', message: 'Select something', message_translation_key: 'asurgentui:FormStory_two' },
-        { property: 'someRadioGroup2', message: 'Select something', message_translation_key: 'asurgentui:FormStory_three' },
+        { property: 'someText', message: 'You need some text', message_translation_key: 'error1' },
+        { property: 'someRadioGroup', message: 'Select something', message_translation_key: 'error2' },
+        { property: 'someRadioGroup2', message: 'Select something', message_translation_key: 'error3' },
         { property: 'someDate', message: 'Pick a date', message_translation_key: 'key_doesnt_exist_will_fallback_on_message' },
         { property: 'someSelect', message: 'Select more things' },
-      ]);
+      ], translation);
     } else {
       formData.errors([]);
     }

--- a/src/Form/Formstories.translation.js
+++ b/src/Form/Formstories.translation.js
@@ -3,13 +3,13 @@ import addTranslation from '../../lib/i18n/addTranslation';
 export default addTranslation({
   id: 'FormStory',
   sv: {
-    one: 'Fält 1 fel',
-    two: 'Fält 2 fel',
-    three: 'Fält 3 fel',
+    error1: 'Fält 1 fel',
+    error2: 'Fält 2 fel',
+    error3: 'Fält 3 fel',
   },
   en: {
-    one: 'Field 1 error',
-    two: 'Field 2 error',
-    three: 'Field 3 error',
+    error1: 'Field 1 error',
+    error2: 'Field 2 error',
+    error3: 'Field 3 error',
   },
 });

--- a/src/Form/components/InputWrapper.styled.js
+++ b/src/Form/components/InputWrapper.styled.js
@@ -92,7 +92,6 @@ export const Error = styled.div`
   font-size: 1.1rem;
   letter-spacing: .1rem;
   color: ${({ theme }) => theme.ruby800};
-  text-transform: capitalize;
   position: absolute; 
   bottom: -2rem;
 `;

--- a/src/Form/hooks/useFormBuilder.js
+++ b/src/Form/hooks/useFormBuilder.js
@@ -15,6 +15,13 @@ const updateValue = (form, change) => {
   return false;
 };
 
+const appendTranslationPrefix = (errorsList, prefix) => errorsList.map(({
+  message_translation_key: t, ...rest
+}) => ({
+  ...rest,
+  message_translation_key: `${prefix}${t}`,
+}));
+
 const updateField = (form, change) => {
   if (form && typeof change === 'object') {
     const { name, value } = change;
@@ -256,7 +263,26 @@ const useFormBuilder = (formSpecification, parameters = null) => {
         setFormData(update);
       }
     },
-    errors: (errorsList) => setErrors(errorsList),
+    errors: (errorsList, translation) => {
+      if (Array.isArray(errorsList)) {
+        // Posibility to pass object translation object
+        // that is returned from lib/i18n/addTranslation.js
+        if (translation
+          && translation instanceof Object
+          && translation.translation
+          && translation.translation.id) {
+          const withPrefix = appendTranslationPrefix(errorsList, translation.translation.id);
+          setErrors(withPrefix);
+          // Simply pass a string that will be used as prefix
+        } else if (typeof translation === 'string') {
+          const withPrefix = appendTranslationPrefix(errorsList, translation);
+          setErrors(withPrefix);
+        } else {
+          // Dont prefix
+          setErrors(errorsList);
+        }
+      }
+    },
     getValues: () => getValues(references, originalValues),
     inputFileds: renderedFields,
     formData,

--- a/src/Form/hooks/useFormBuilder.js
+++ b/src/Form/hooks/useFormBuilder.js
@@ -267,10 +267,7 @@ const useFormBuilder = (formSpecification, parameters = null) => {
       if (Array.isArray(errorsList)) {
         // Posibility to pass object translation object
         // that is returned from lib/i18n/addTranslation.js
-        if (translation
-          && translation instanceof Object
-          && translation.translation
-          && translation.translation.id) {
+        if (translation && translation instanceof Object && translation?.translation?.id) {
           const withPrefix = appendTranslationPrefix(errorsList, translation.translation.id);
           setErrors(withPrefix);
           // Simply pass a string that will be used as prefix

--- a/src/layout/DropdownCreate/DropdownCreate.styled.js
+++ b/src/layout/DropdownCreate/DropdownCreate.styled.js
@@ -6,6 +6,8 @@ export const MenuWrapper = styled.div`
 `;
 
 export const DesktopMenu = styled.div`
+    display: flex;
+    flex-direction: column;
     position: absolute;
     width: auto;
     min-width: 28rem;
@@ -25,7 +27,6 @@ export const DesktopMenu = styled.div`
         margin-top: .8rem;
         margin-bottom: 1.6rem;
     }
-    
 `;
 
 


### PR DESCRIPTION
# Description

Change how we construct the translation key objects. Previously we added a underscore between the translation id and key. I simply removed the underscore since it didn't really give us anything.

This helped us to make it easier to create translations for form-validation errors, since we simply can pass the ID or if we want the entire translation object returned from addTranslation.js

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Cant be tested in the portal other than making sure that all translations work as expected still.
- Check that error-labels render in `Default Form story `

# Author checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [x] The code runs without errors and/or warnings
- [x] The code followsthe style guidelines of this project
- [x] The documentation is sufficinent 
- [x] The tests runs withour errors and covers all/most states/scenarios
- [x] The component/changes are represented in storybook
