### PR TITLE
tooltip - linebreaks and colors

### DIFF
--- a/src/Tooltip/Tooltip.stories.js
+++ b/src/Tooltip/Tooltip.stories.js
@@ -8,9 +8,16 @@ const center = {
   height: '100vh', width: '100vw', display: 'flex', justifyContent: 'center', alignItems: 'center',
 };
 
+const someFormattedToolTip = `Headertext blablabal:
+
+Some paragraphy text text text text text text text.
+
+Some other text.
+`;
+
 export const bottomMiddle = () => (
   <div style={center}>
-    <Tooltip.Middle tip="Hello">
+    <Tooltip.Middle tip={someFormattedToolTip}>
       <h1 style={{ display: 'inline-block' }}>Hover me</h1>
     </Tooltip.Middle>
   </div>

--- a/src/Tooltip/Tooltip.styled.js
+++ b/src/Tooltip/Tooltip.styled.js
@@ -7,7 +7,7 @@ export const TooltipWrapper = styled.div`
   position: fixed;
   background-color: #161616;
   padding: .8rem;
-  border-radius: 3px;
+  border-radius: 5px;
   transform: ${({ position }) => {
     switch (position) {
       case 'left':
@@ -19,7 +19,10 @@ export const TooltipWrapper = styled.div`
     }
   }};
   
-  color: #ffffff;
+  box-shadow: 0 6px 10px -5px ${({ theme }) => theme.rgba(theme.black, 0.2)};
+  background: ${({ theme }) => theme.white};
+  color: ${({ theme }) => theme.black};
+  white-space: pre;
   display: none;
 
   @media screen and (min-width: ${(prop) => `${prop.theme.breakPointTablet * 10}px`}) {


### PR DESCRIPTION
# Description

Make tooltips respect linebreaks in texts, and make them look more like the popover-tooltips we had on Alert Rules-page

Fixes # https://github.com/asurgent/admin/issues/918

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

In storybook:

- [ ] Go to Tooltip and see that it behaves as expected on right/left still works (small input-text)
- [ ] Go to Tooltip and see that bottom works (long formatted text)

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
