### PR TITLE
tooltipfix, and removed block from adding colors

### DIFF
--- a/src/Block/Block.styled.js
+++ b/src/Block/Block.styled.js
@@ -16,7 +16,6 @@ export const BaseBlock = styled.div`
   }};
     padding: ${({ withPadding }) => (withPadding ? '1.6rem' : 0)};
     background: ${({ renderTransparent, theme }) => (renderTransparent === true ? 'transparent' : theme.white)};
-    color: ${({ theme }) => theme.black};
     
     @media screen and (min-width: ${(prop) => `${prop.theme.breakPointMobile * 10}px`}) {
         padding: ${({ withPadding }) => (withPadding ? '3.2rem' : 0)};

--- a/src/Tooltip/Tooltip.styled.js
+++ b/src/Tooltip/Tooltip.styled.js
@@ -8,6 +8,8 @@ export const TooltipWrapper = styled.div`
   background-color: #161616;
   padding: .8rem;
   border-radius: 5px;
+  max-width: max(20rem, 25vw);
+  white-space: pre-wrap;
   transform: ${({ position }) => {
     switch (position) {
       case 'left':
@@ -19,10 +21,7 @@ export const TooltipWrapper = styled.div`
     }
   }};
   
-  box-shadow: 0 6px 10px -5px ${({ theme }) => theme.rgba(theme.black, 0.2)};
-  background: ${({ theme }) => theme.white};
-  color: ${({ theme }) => theme.black};
-  white-space: pre;
+  color: ${({ theme }) => theme.white};
   display: none;
 
   @media screen and (min-width: ${(prop) => `${prop.theme.breakPointTablet * 10}px`}) {


### PR DESCRIPTION
# Description

tooltip back to black and fix so that it doesnt overflow the screen, and removed block from adding colors

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] npm run copy -> go to alert rules and see that tooltip isnt overflowing the screen & is black, and that the text in the description is white, not black

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
