### PR TITLE
disable categories from being selectable

### DIFF
--- a/src/Table/TableFilter/components/FilterItem.js
+++ b/src/Table/TableFilter/components/FilterItem.js
@@ -31,7 +31,7 @@ const FilterItem = ({
   return (
     <C.FilterItem
       matched={hook.isMatched()}
-      canClick={filterItem.matched}
+      disabled={filterItem.static || filterItem.label}
       onClick={() => {
         onChange(filterItem);
         onAdd(filterItem);

--- a/src/Table/TableFilter/components/FilterItem.js
+++ b/src/Table/TableFilter/components/FilterItem.js
@@ -31,6 +31,7 @@ const FilterItem = ({
   return (
     <C.FilterItem
       matched={hook.isMatched()}
+      canClick={filterItem.matched}
       onClick={() => {
         onChange(filterItem);
         onAdd(filterItem);

--- a/src/Table/TableFilter/components/FilterItem.styled.js
+++ b/src/Table/TableFilter/components/FilterItem.styled.js
@@ -22,7 +22,7 @@ export const FilterItem = styled.div`
     &:hover {
         background: ${({ theme }) => theme.gray50};
     }
-    pointer-events: ${({ canClick }) => (canClick ? 'all' : 'none')};
+    pointer-events: ${({ disabled }) => (disabled ? 'none' : 'all')};
 `;
 
 export const FilterLabel = styled.div`

--- a/src/Table/TableFilter/components/FilterItem.styled.js
+++ b/src/Table/TableFilter/components/FilterItem.styled.js
@@ -22,6 +22,7 @@ export const FilterItem = styled.div`
     &:hover {
         background: ${({ theme }) => theme.gray50};
     }
+    pointer-events: ${({ canClick }) => (canClick ? 'all' : 'none')};
 `;
 
 export const FilterLabel = styled.div`


### PR DESCRIPTION
# Description

Remove possibility to add the categories themselves to the filter, only entries should be clickable.

Fixes https://github.com/asurgent/admin/issues/939

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [ ] Go to Table -> Filter -> Open the Guys filter, and change selections, and try to add "Valda"/"Tillgängliga", should not work
- [ ] Same as above but for pankaka

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
