### PR TITLE
override for cardcontainers & translation-fix

### DIFF
--- a/src/Table/BaseTable/BaseTable.js
+++ b/src/Table/BaseTable/BaseTable.js
@@ -9,7 +9,6 @@ import * as C from './BaseTable.styled';
 import generateRows from './helpers';
 import translation from './BaseTable.translation';
 
-
 export const propTypes = {
   canExportResults: PropTypes.bool,
   exportFileName: PropTypes.string,
@@ -43,6 +42,10 @@ export const propTypes = {
     PropTypes.func,
     PropTypes.bool,
   ]),
+  cardComponent: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.bool,
+  ]),
   cardView: PropTypes.bool,
   equalSizeColumns: PropTypes.bool,
   isLoading: PropTypes.bool,
@@ -61,6 +64,7 @@ export const defaultProps = {
   tableRowConfiguration: false,
   cellComponent: false,
   rowComponent: false,
+  cardComponent: false,
   equalSizeColumns: false,
   isLoading: false,
   emptystate: '',
@@ -72,6 +76,7 @@ export const defaultProps = {
 const bodyComponents = {
   cell: C.Cell,
   row: C.Row,
+  card: C.Card,
   content: C.TableCellContent,
 };
 

--- a/src/Table/BaseTable/BaseTable.styled.js
+++ b/src/Table/BaseTable/BaseTable.styled.js
@@ -103,6 +103,16 @@ export const Cell = styled.div`
     align-items: center;
 `;
 
+export const Card = styled.div`
+    display: flex;
+    padding: .8rem;
+    position: relative;
+    overflow: hidden;
+    min-height: 5.6rem;
+    align-items: center;
+`;
+
+
 export const TableCellContent = styled.div`
     margin: 0;
     padding: 0;

--- a/src/Table/BaseTable/helpers.js
+++ b/src/Table/BaseTable/helpers.js
@@ -107,25 +107,28 @@ const generateCells = (props, rowData, components) => {
     });
 };
 
-const generateCard = (props, columnData, components) => {
-  const { cardConfiguration } = props;
-  const content = cardConfiguration(columnData);
-  const CellComponent = components.cell;
-
-  const element = (
-    <CellComponent key={`${columnData.id}-card`} cardView>
-      {content}
-    </CellComponent>
-  );
-
-  return element;
-};
-
 const generateRowId = (columnData, index) => {
   if (!columnData.id) {
     const id = `row-id-${new Date().getTime()}-${index}`;
     Object.assign(columnData, { id });
   }
+};
+
+const generateCard = (props, cardData, components) => {
+  const { cardConfiguration, cardComponent } = props;
+
+  const content = cardConfiguration(cardData);
+  const { props: cardProps } = content;
+
+  const CardContainer = cardComponent ? cardComponent(components, cardData) : components.card;
+
+  const element = (
+    <CardContainer {...cardProps} key={`${cardData.id}-card`} cardView>
+      {content}
+    </CardContainer>
+  );
+
+  return element;
 };
 
 const generateRows = (props, components) => props.rowData
@@ -134,12 +137,13 @@ const generateRows = (props, components) => props.rowData
     const { cardView } = props;
 
     if (cardView && typeof props.cardConfiguration === 'function') {
+    /*   console.log('props', props);
+      console.log('components', components); */
       const card = generateCard(props, rowData, components);
       acc.push(card);
     } else {
       // Make it possible to override default styling of rows
       const Row = props.rowComponent ? props.rowComponent(components, rowData) : components.row;
-
       const row = (
         <Row
           key={rowData.id}

--- a/src/Table/BaseTable/helpers.js
+++ b/src/Table/BaseTable/helpers.js
@@ -137,8 +137,6 @@ const generateRows = (props, components) => props.rowData
     const { cardView } = props;
 
     if (cardView && typeof props.cardConfiguration === 'function') {
-    /*   console.log('props', props);
-      console.log('components', components); */
       const card = generateCard(props, rowData, components);
       acc.push(card);
     } else {

--- a/src/Table/Table.stories.js
+++ b/src/Table/Table.stories.js
@@ -97,6 +97,15 @@ const rowComponentOverride = ({ row }) => {
   return OverrideRow;
 };
 
+const cardComponentOverride = ({ card }) => {
+  const OverrideCard = styled(card)`
+    background: magenta;
+    border: 4px solid cyan;
+    padding: 2rem;
+  `;
+  return OverrideCard;
+};
+
 const cellComponentOverride = ({ cell }) => {
   const OverrideCell = styled(cell)`
     padding:  3.2rem .8rem;
@@ -113,6 +122,7 @@ export const base = () => (
     <Table.Base
       cellComponent={cellComponentOverride}
       rowComponent={rowComponentOverride}
+      cardComponent={cardComponentOverride}
       emptystate={text('Emptystate', 'No items found')}
       isLoading={boolean('Loading', false)}
       zebra={boolean('Zebra', true)}

--- a/src/TimeComponents/components/Duration/Duration.js
+++ b/src/TimeComponents/components/Duration/Duration.js
@@ -42,7 +42,7 @@ const Duration = ({
           {t('duration', 'asurgentui') }
         </S.TextSmall>
         <Icons.Duration active={false} />
-        <S.TextNormal>{t('cron', 'asurgentui')}</S.TextNormal>
+        <S.TextNormal>{t('naIcon', 'asurgentui')}</S.TextNormal>
         <S.TextSmall>{t('invalid', 'asurgentui')}</S.TextSmall>
       </C.Repeat>
     );

--- a/src/TimeComponents/components/Duration/Duration.translation.js
+++ b/src/TimeComponents/components/Duration/Duration.translation.js
@@ -5,7 +5,7 @@ export default addTranslation({
   sv: {
     duration: 'Varar',
     remaining: 'Kvar',
-    cron: 'CRON',
+    naIcon: 'Ø',
     invalid: 'Ogiltig',
     seconds: 'Sekunder',
     minutes: 'Minuter',
@@ -17,7 +17,7 @@ export default addTranslation({
   en: {
     duration: 'Duration',
     remaining: 'Remaining',
-    cron: 'CRON',
+    naIcon: 'Ø',
     invalid: 'Invalid',
     seconds: 'Seconds',
     minutes: 'Minutes',


### PR DESCRIPTION
# Description

Need to be able to override the card component's standard CSS for some purposes, a fix for that. Plus a tiny translation fix.

Related to https://github.com/asurgent/admin/issues/958

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] Go to Table -> Base and toggle CardView, and in the Table.stories.js-file change the CSS in the new cardComponent-prop (in other words change in the cardComponentOverride-func), and check that it can override what's written in BaseTable.styled.js. 

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
