### PR TITLE
Perserve search-state for tables

### DIFF
--- a/src/Table/TableSearchBar/useSearchbarHook.js
+++ b/src/Table/TableSearchBar/useSearchbarHook.js
@@ -29,7 +29,7 @@ const useSearchbarHook = (tableHook) => {
       if (state && Object.keys(state).length) {
         const { text } = state;
         if (text !== undefined) {
-          setQuery(text);
+          setQuery(decodeURIComponent(text));
         }
       }
 
@@ -43,7 +43,7 @@ const useSearchbarHook = (tableHook) => {
       // Execute change component has been target from another hook
       const { search } = tableHook.thirdPartyTrigger;
       if (search !== undefined) {
-        setQuery(search);
+        setQuery(decodeURIComponent(search));
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -53,7 +53,7 @@ const useSearchbarHook = (tableHook) => {
   useEffect(() => {
     if (isReady) {
       const request = { search_string: `${parseQuery(query)}` };
-      const history = { search: `${query}` };
+      const history = { search: `${encodeURIComponent(query)}` };
       const trigger = { page: 1 };
 
       // Check if this is the first render-cycle


### PR DESCRIPTION
# Description

Encode/encode search-string so i doesn't get cleaned  up bu the broser on refresh

Fixes https://github.com/asurgent/admin/issues/942

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Run saga locally or use the hosted version
- Go to http://localhost:6006/iframe.html?id=ui-components-table--main&tickets_q=%2522Test%2522%2520%2522%253A%252F%252F%2522%20
- The search-string the the table should be `"Test" "://" `


# Author checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [x] The code runs without errors and/or warnings
- [x] The code followsthe style guidelines of this project
- [x] The documentation is sufficinent 
- [x] The tests runs withour errors and covers all/most states/scenarios
- [x] The component/changes are represented in storybook
