### PR TITLE
Cant submit form without bluring fields first

### DIFF
--- a/src/Block/Block.stories.js
+++ b/src/Block/Block.stories.js
@@ -116,7 +116,11 @@ export const subnavigationBlock = () => (
     <h1>I am title</h1>
     <Block.Bordered noShadow withPadding>
       <h2>Did you come in early?</h2>
-      <p>Let your colleages sleep and snooze the On Call phone. When you hit the snooze button the On Call phone will no longer be active and calls will be redirected to you instead.</p>
+      <p>
+        Let your colleages sleep and snooze the On Call phone.
+        When you hit the snooze button the On Call phone will no
+        longer be active and calls will be redirected to you instead.
+      </p>
     </Block.Bordered>
   </Block.SubnavigationBlock>
 );

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -94,7 +94,6 @@ const Button = (props) => {
         onClick(event);
       }
 
-
       if (isValidLink && isInteralLink(link)) {
         event.preventDefault();
 
@@ -113,6 +112,7 @@ const Button = (props) => {
   const attrs = {
     className: [(disabled ? 'disabled' : null), className].join(' ').trim(),
     onClick: handleClick,
+    onMouseDown: (e) => e.preventDefault(),
   };
 
   const TooltipWrapper = ({ children: tooltipChildren }) => {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -112,6 +112,7 @@ const Button = (props) => {
   const attrs = {
     className: [(disabled ? 'disabled' : null), className].join(' ').trim(),
     onClick: handleClick,
+    // onMouseDown needed because of onBlur on form fields
     onMouseDown: (e) => e.preventDefault(),
   };
 

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -12,12 +12,12 @@ export default { title: 'UI Components|Buttons', decorators: [withKnobs] };
 
 export const saveToFileButton = () => (
   <>
-    <Button.Icon saveToFilename="some_file" tooltip="Saves from promise" saveToJson={() => new Promise((r) => r(['a', 'b']))} icon={<Icon.ConfirmationNumber fontSize="large" onClick={() => action('Click!')} />} />
-    <Button.Icon saveToFilename="another_file" tooltip="Saves from object" saveToJson={() => ['a', 'b']} icon={<Icon.ConfirmationNumber fontSize="large" onClick={() => action('Click!')} />} />
+    <Button.Icon saveToFilename="some_file" tooltip="Saves from promise" saveToJson={() => new Promise((r) => r(['a', 'b']))} icon={<Icon.ConfirmationNumber fontSize="large" onClick={(e) => action('Clicked!')(e)} />} />
+    <Button.Icon saveToFilename="another_file" tooltip="Saves from object" saveToJson={() => ['a', 'b']} icon={<Icon.ConfirmationNumber fontSize="large" onClick={(e) => action('Clicked!')(e)} />} />
   </>
 );
 export const iconButton = () => (
-  <Button.Icon tooltip="Hello" saveLinkState link="/test" icon={<Icon.ConfirmationNumber fontSize="large" onClick={() => action('Click!')} />} />
+  <Button.Icon tooltip="Hello" saveLinkState link="/test" icon={<Icon.ConfirmationNumber fontSize="large" onClick={(e) => action('Clicked!')(e)} />} />
 );
 
 export const submitButton = () => (
@@ -31,47 +31,47 @@ export const submitButton = () => (
 );
 
 export const primaryButton = () => (
-  <Button.Primary loading={boolean('loading', true)} onClick={() => action('Click!')}>{content}</Button.Primary>
+  <Button.Primary loading={boolean('loading', true)} onClick={(e) => action('Clicked!')(e)}>{content}</Button.Primary>
 );
 
 export const secondaryButton = () => (
-  <Button.Secondary onClick={() => action('Click!')}>{content}</Button.Secondary>
+  <Button.Secondary onClick={(e) => action('Clicked!')(e)}>{content}</Button.Secondary>
 );
 
 export const hollowButton = () => (
-  <Button.Hollow onClick={() => action('Click!')}>{content}</Button.Hollow>
+  <Button.Hollow onClick={(e) => action('Clicked!')(e)}>{content}</Button.Hollow>
 );
 
 export const hrefButton = () => (
-  <Button.Primary disabled link="https://google.com" onClick={() => action('Click!')}>{content}</Button.Primary>
+  <Button.Primary disabled link="https://google.com" onClick={(e) => action('Clicked!')(e)}>{content}</Button.Primary>
 );
 
 export const plainButton = () => (
-  <Button.Plain onClick={() => action('Click!')}>{content}</Button.Plain>
+  <Button.Plain onClick={(e) => action('Clicked!')(e)}>{content}</Button.Plain>
 );
 
 export const linkButton = () => (
-  <Button.Link iconLeft={<Icon.ConfirmationNumber fontSize="medium" onClick={() => action('Click!')} />}>{content}</Button.Link>
+  <Button.Link iconLeft={<Icon.ConfirmationNumber fontSize="medium" onClick={(e) => action('Clicked!')(e)} />}>{content}</Button.Link>
 );
 
 export const transparentButton = () => (
-  <Button.Transparent onClick={() => action('Click!')}>{content}</Button.Transparent>
+  <Button.Transparent onClick={(e) => action('Clicked!')(e)}>{content}</Button.Transparent>
 );
 
 export const rejectButton = () => (
-  <Button.Reject onClick={() => action('Click!')}>{content}</Button.Reject>
+  <Button.Reject onClick={(e) => action('Clicked!')(e)}>{content}</Button.Reject>
 );
 
 export const acceptButton = () => (
-  <Button.Create onClick={() => action('Click!')}>{content}</Button.Create>
+  <Button.Create onClick={(e) => action('Clicked!')(e)}>{content}</Button.Create>
 );
 
 export const pillButton = () => (
-  <Button.Pill onClick={() => action('Click!')}>{content}</Button.Pill>
+  <Button.Pill onClick={(e) => action('Clicked!')(e)}>{content}</Button.Pill>
 );
 
 export const tooltipButton = () => (
-  <Button.Primary tooltip="hello" tooltipOrientation={text('orientation (middle,left,right)', 'middle')} onClick={() => action('Click!')}>
+  <Button.Primary tooltip="hello" tooltipOrientation={text('orientation (middle,left,right)', 'middle')} onClick={(e) => action('Clicked!')(e)}>
     {content}
   </Button.Primary>
 );

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -12,12 +12,12 @@ export default { title: 'UI Components|Buttons', decorators: [withKnobs] };
 
 export const saveToFileButton = () => (
   <>
-    <Button.Icon saveToFilename="some_file" tooltip="Saves from promise" saveToJson={() => new Promise((r) => r(['a', 'b']))} icon={<Icon.ConfirmationNumber fontSize="large" />} />
-    <Button.Icon saveToFilename="another_file" tooltip="Saves from object" saveToJson={() => ['a', 'b']} icon={<Icon.ConfirmationNumber fontSize="large" />} />
+    <Button.Icon saveToFilename="some_file" tooltip="Saves from promise" saveToJson={() => new Promise((r) => r(['a', 'b']))} icon={<Icon.ConfirmationNumber fontSize="large" onClick={() => action('Click!')} />} />
+    <Button.Icon saveToFilename="another_file" tooltip="Saves from object" saveToJson={() => ['a', 'b']} icon={<Icon.ConfirmationNumber fontSize="large" onClick={() => action('Click!')} />} />
   </>
 );
 export const iconButton = () => (
-  <Button.Icon tooltip="Hello" saveLinkState link="/test" icon={<Icon.ConfirmationNumber fontSize="large" />} />
+  <Button.Icon tooltip="Hello" saveLinkState link="/test" icon={<Icon.ConfirmationNumber fontSize="large" onClick={() => action('Click!')} />} />
 );
 
 export const submitButton = () => (
@@ -31,47 +31,47 @@ export const submitButton = () => (
 );
 
 export const primaryButton = () => (
-  <Button.Primary loading={boolean('loading', true)}>{content}</Button.Primary>
+  <Button.Primary loading={boolean('loading', true)} onClick={() => action('Click!')}>{content}</Button.Primary>
 );
 
 export const secondaryButton = () => (
-  <Button.Secondary>{content}</Button.Secondary>
+  <Button.Secondary onClick={() => action('Click!')}>{content}</Button.Secondary>
 );
 
 export const hollowButton = () => (
-  <Button.Hollow>{content}</Button.Hollow>
+  <Button.Hollow onClick={() => action('Click!')}>{content}</Button.Hollow>
 );
 
 export const hrefButton = () => (
-  <Button.Primary disabled link="https://google.com">{content}</Button.Primary>
+  <Button.Primary disabled link="https://google.com" onClick={() => action('Click!')}>{content}</Button.Primary>
 );
 
 export const plainButton = () => (
-  <Button.Plain>{content}</Button.Plain>
+  <Button.Plain onClick={() => action('Click!')}>{content}</Button.Plain>
 );
 
 export const linkButton = () => (
-  <Button.Link iconLeft={<Icon.ConfirmationNumber fontSize="medium" />}>{content}</Button.Link>
+  <Button.Link iconLeft={<Icon.ConfirmationNumber fontSize="medium" onClick={() => action('Click!')} />}>{content}</Button.Link>
 );
 
 export const transparentButton = () => (
-  <Button.Transparent>{content}</Button.Transparent>
+  <Button.Transparent onClick={() => action('Click!')}>{content}</Button.Transparent>
 );
 
 export const rejectButton = () => (
-  <Button.Reject>{content}</Button.Reject>
+  <Button.Reject onClick={() => action('Click!')}>{content}</Button.Reject>
 );
 
 export const acceptButton = () => (
-  <Button.Create>{content}</Button.Create>
+  <Button.Create onClick={() => action('Click!')}>{content}</Button.Create>
 );
 
 export const pillButton = () => (
-  <Button.Pill>{content}</Button.Pill>
+  <Button.Pill onClick={() => action('Click!')}>{content}</Button.Pill>
 );
 
 export const tooltipButton = () => (
-  <Button.Primary tooltip="hello" tooltipOrientation={text('orientation (middle,left,right)', 'middle')}>
+  <Button.Primary tooltip="hello" tooltipOrientation={text('orientation (middle,left,right)', 'middle')} onClick={() => action('Click!')}>
     {content}
   </Button.Primary>
 );

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -48,8 +48,8 @@ const Form = (props) => {
     children,
     msTimer,
     onSubmit,
-    onBlur,
     onFocus,
+    onBlur,
     onChange,
     onChangeTimer,
     onKeyUp,
@@ -91,23 +91,22 @@ const Form = (props) => {
   const eventTrigger = ({
     name = null, timerAction = null, action = null, reRender = false, setDirty = true,
   }) => {
-    setTimeout(() => {
-      const { values, dirty, dirtyItems } = hook.getValues();
-      if (setDirty) {
-        setIsDirty(dirty);
-      }
-      if (reRender) {
-        hook.renderItems(values);
-      }
-      if (timerAction) {
-        timerAction(values, dirty, dirtyItems);
-      }
-      action(values, dirty, dirtyItems, name);
-    }, 0);
+    const { values, dirty, dirtyItems } = hook.getValues();
+    if (setDirty) {
+      setIsDirty(dirty);
+    }
+    if (reRender) {
+      hook.renderItems(values);
+    }
+    if (timerAction) {
+      timerAction(values, dirty, dirtyItems);
+    }
+    action(values, dirty, dirtyItems, name);
   };
 
   const onSubmitAction = () => {
-    eventTrigger({ action: onSubmit });
+    hook.blurFields();
+    eventTrigger({ action: onSubmit, setDirty: false });
   };
 
   const onResetAction = () => {
@@ -143,7 +142,7 @@ const Form = (props) => {
       }}
       onSubmit={(event) => {
         event.preventDefault();
-        eventTrigger({ action: onSubmit });
+        eventTrigger({ action: onSubmit, setDirty: false });
       }}
       onFocus={(event) => {
         const { name } = event.target;

--- a/src/Form/Form.js
+++ b/src/Form/Form.js
@@ -111,6 +111,7 @@ const Form = (props) => {
 
   const onResetAction = () => {
     setIsDirty(false);
+    hook.blurFields();
     hook.resetValues();
   };
 

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -183,7 +183,7 @@ export const defaultForm = () => {
   }, [renderErrors]);
 
   return (
-    <div style={{ minHeight: '120vh' }}>
+    <div style={{}}>
       <Form.Primary
         form={formData}
         msTimer={15}
@@ -206,11 +206,7 @@ export const defaultForm = () => {
               <Button.Secondary disabled={!isDirty} onClick={onResetAction}>
                 Reset
               </Button.Secondary>
-              <Button.Primary
-                onClick={(e) => onSubmitAction(e)}
-              >
-                Submit
-              </Button.Primary>
+              <Button.Primary onClick={onSubmitAction}>Submit</Button.Primary>
             </Block.SpaceBetween>
           </>
         )}

--- a/src/Form/Form.test.js
+++ b/src/Form/Form.test.js
@@ -51,45 +51,30 @@ MyForm.propTypes = {
 };
 
 describe('Button', () => {
-  test('The form submits when clicking the submit button, even when fields are not yet blurred', async () => {
+  test('The reset button isnt showing (isDirty) just because of a click on a field', async () => {
     const props = {
       subTitle: 'Submit', resetTitle: 'Reset', disabled: true, onClick: jest.fn(),
     };
 
     const rend = render(<MyForm {...props} />);
-    const { queryByText, queryByDisplayValue, rerender } = rend;
+    const {
+      queryByText, queryByDisplayValue, rerender,
+    } = rend;
+
     const subBtn = queryByText(props.subTitle);
-    expect(subBtn).toBeDefined();
+    expect(subBtn).not.toBeNull();
 
     // check that a button is hidden on !isDirty
-    let resetBtn = queryByText(props.resetTitle);
+    const resetBtn = queryByText(props.resetTitle);
     expect(resetBtn).toBeNull();
 
     const textInput = queryByDisplayValue('My value');
     expect(textInput).toBeDefined();
 
-    act(() => textInput.focus());
+    act(() => textInput.click());
     rerender(<MyForm {...props} />);
 
-    // check that a button is visible on isDirty
-    resetBtn = queryByText(props.resetTitle);
-    expect(resetBtn).toBeDefined();
-
-    // TODO: klicking a field without changing anything turns the form dirty. should not.
-    // have to blur fields before being able to click the submit button also.
-
-    /*
-    textInput = rend.getByDisplayValue('My value');
-    expect(textInput).toBeDefined();
-
-
-    textInput = rend.getByDisplayValue('My value');
-    expect(textInput).toBeDefined();
-
-
-    fireEvent.click(subBtn);
-    expect(props.onClick).toHaveBeenCalled(); */
-    /*  const btnTitle = getByText(props.btnTitle);
-    expect(btnTitle).toBeDefined(); */
+    // check that button still hidden after click on a field
+    expect(queryByText(props.resetTitle)).toBeNull();
   });
 });

--- a/src/Form/hooks/useFormBuilder.js
+++ b/src/Form/hooks/useFormBuilder.js
@@ -136,7 +136,7 @@ const useFormBuilder = (formSpecification, parameters = null) => {
     blurFields: () => {
       Object.keys(references).forEach((key) => {
         const input = references[key];
-        if (input && input.current) {
+        if (input?.current?.tagName === 'INPUT') {
           input.current.blur();
         }
       });

--- a/src/Form/hooks/useFormBuilder.js
+++ b/src/Form/hooks/useFormBuilder.js
@@ -133,6 +133,14 @@ const useFormBuilder = (formSpecification, parameters = null) => {
         input.current.blur();
       }
     },
+    blurFields: () => {
+      Object.keys(references).forEach((key) => {
+        const input = references[key];
+        if (input && input.current) {
+          input.current.blur();
+        }
+      });
+    },
     addField: (key, field) => {
       if (Object.prototype.hasOwnProperty.call(formData, key) === false) {
         const copy = { ...formData, [key]: field };


### PR DESCRIPTION
# Description

If a form field still has focus you cant submit the form (or click cancel/reset) without blurring the field first. So for example clicking on a radio button, you have to click somewhere else first before being able to click on the form buttons. Fix for that. 

Fixes https://github.com/asurgent/admin/issues/985

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Go to http://localhost:6006/?path=/story/ui-components-form--default-form and either start typing in the text field or click on one of the radios, then immediately click on the Reset or Submit-button and it should reset/submit. So no need to click somewhere else first before Reset/Submit responds to the user action.

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
