### PR TITLE
option for not adding the first option as default on select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5514,9 +5514,9 @@
       "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
     },
     "caniuse-lite": {
-      "version": "1.0.30001113",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001113.tgz",
-      "integrity": "sha512-qMvjHiKH21zzM/VDZr6oosO6Ri3U0V2tC015jRXjOecwQCJtsU5zklTNTk31jQbIOP8gha0h1ccM/g0ECP+4BA==",
+      "version": "1.0.30001114",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001114.tgz",
+      "integrity": "sha512-ml/zTsfNBM+T1+mjglWRPgVsu2L76GAaADKX5f4t0pbhttEp0WMawJsHDYlFkVZkoA+89uvBRrVrEE4oqenzXQ==",
       "dev": true
     },
     "capture-exit": {
@@ -12215,9 +12215,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -98,11 +98,12 @@ export const defaultForm = () => {
       type: 'select',
       label: 'Some Select',
       options: [
-        { value: '1', label: 'First option', default: true },
+        { value: '1', label: 'First option' },
         { value: '2', label: 'Second option' },
         { value: '3', label: 'Third option' },
       ],
       tooltip: 'tooltip',
+      placeholder: 'Select something',
     },
     someFilterSelectSingle: {
       type: 'filterselect',
@@ -140,7 +141,7 @@ export const defaultForm = () => {
       { name: 'someNumber', value: 10 },
       { name: 'someRadioGroup', value: 'value1' },
       { name: 'someRadioGroup2', value: 'value4' },
-      { name: 'someSelect', value: '3' },
+      { name: 'someSelect', value: null },
       {
         name: 'someFilterSelectSingle',
         value: '2',

--- a/src/Form/types/Select/Select.js
+++ b/src/Form/types/Select/Select.js
@@ -7,11 +7,13 @@ const propTyps = {
   name: PropTypes.string.isRequired,
   options: PropTypes.arrayOf(PropTypes.instanceOf(Object)).isRequired,
   props: PropTypes.instanceOf(Object),
+  placeholder: PropTypes.string,
 };
 
 const defaultProps = {
   value: '',
   props: {},
+  placeholder: '',
 };
 
 const getDefaultSort = (sortKeys) => {
@@ -33,7 +35,7 @@ const Select = forwardRef((props, ref) => {
   const {
     name,
     options,
-
+    placeholder,
   } = props;
 
   const [value, setValue] = useState('');
@@ -57,6 +59,11 @@ const Select = forwardRef((props, ref) => {
         name={name}
         ref={ref}
       >
+        {placeholder && (
+        <option disabled value="">
+          {placeholder}
+        </option>
+        )}
         { Array.isArray(options) && options
           .map(({
             value: optionValue,


### PR DESCRIPTION
# Description

Need to have an option for the select type to not automatically add the first option as selected by default.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Go to http://localhost:6006/?path=/story/ui-components-form--default-form, and select something on the "Some select" and see that it changes, submits the correct value and resets correctly when pressing Reset.
- [ ] In Form.stories.js on row 138 (formData.updateFields...), change the value of someSelect from null to '1', '2', or '3', and see that it still works as expected.

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
