### PR TITLE
fix for tag overflow & max length of tags in collections

### DIFF
--- a/src/Tag/Tag.stories.js
+++ b/src/Tag/Tag.stories.js
@@ -12,7 +12,7 @@ export const singeTag = () => (
     <Tag.Single
       onDelete={boolean('Has delete action', false) ? (action('click')) : false}
       label={text('Tag label', 'Tag')}
-      max={number('Max letter count (0 is unlimited)', 0)}
+      maxLength={number('Max letter count (0 is unlimited)', 0)}
     />
   </>
 );
@@ -25,7 +25,11 @@ export const tagCollection = () => {
   const tags = Array.from({ length: 10 }, (_, i) => `Tag-${i}`);
   return (
     <>
-      <Tag.Collection tags={tags} max={number('Max tags (0 is unlimited)', 0)} />
+      <Tag.Collection
+        tags={tags}
+        maxTags={number('Max tags (0 is unlimited)', 0)}
+        maxLength={number('Max letter count (0 is unlimited', 0)}
+      />
     </>
   );
 };
@@ -41,7 +45,11 @@ export const tagCollectionObject = () => {
   }));
   return (
     <>
-      <Tag.Collection tags={tags} max={number('Max tags (default is unlimited)', 0)} />
+      <Tag.Collection
+        tags={tags}
+        maxTags={number('Max tags (default is unlimited)', 0)}
+        maxLength={number('Max letter count (0 is unlimited', 0)}
+      />
     </>
   );
 };

--- a/src/Tag/components/Tag.js
+++ b/src/Tag/components/Tag.js
@@ -5,7 +5,7 @@ import * as Button from '../../Button';
 
 const propTypes = {
   label: PropTypes.string.isRequired,
-  max: PropTypes.number,
+  maxLength: PropTypes.number,
   component: PropTypes.elementType.isRequired,
   onDelete: PropTypes.oneOfType([
     PropTypes.bool,
@@ -15,16 +15,16 @@ const propTypes = {
 
 const defaultProps = {
   onDelete: false,
-  max: 0,
+  maxLength: 0,
 };
 
 const Tag = ({
-  label, component: Styled, onDelete, max,
+  label, component: Styled, onDelete, maxLength,
 }) => {
   let parsedLabel = label;
 
-  if (max > 0 && label.length > max) {
-    parsedLabel = `${label.substr(0, max)}...`;
+  if (maxLength > 0 && label.length > maxLength) {
+    parsedLabel = `${label.substr(0, maxLength)}...`;
   }
 
   return (

--- a/src/Tag/components/Tag.styled.js
+++ b/src/Tag/components/Tag.styled.js
@@ -9,10 +9,14 @@ export const Default = styled.div`
     background: ${({ theme }) => theme.white};
     display: flex;
     align-items: center;
-    
+    max-width: 100%;
+
     .label {
         padding: .4rem;
         display: inline-block;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     ${Button.Plain} {

--- a/src/Tag/components/TagCollection.js
+++ b/src/Tag/components/TagCollection.js
@@ -4,7 +4,8 @@ import { TagsCollection, SpillOver } from './Tag.styled';
 import TagSingle from './TagSingle';
 
 const propTypes = {
-  max: PropTypes.number,
+  maxTags: PropTypes.number,
+  maxLength: PropTypes.number,
   tags: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.arrayOf(PropTypes.shape({ label: PropTypes.string })),
@@ -12,17 +13,18 @@ const propTypes = {
 };
 
 const defaultProps = {
-  max: 0,
+  maxTags: 0,
+  maxLength: 0,
 };
 
-const TagCollection = ({ tags, max }) => {
+const TagCollection = ({ tags, maxTags, maxLength }) => {
   let spillOver = 0;
   let tagsList = tags;
-  if (max > 0) {
-    tagsList = [...tags].splice(0, max);
+  if (maxTags > 0) {
+    tagsList = [...tags].splice(0, maxTags);
 
     if (tagsList.length < tags.length) {
-      spillOver = tags.length - max;
+      spillOver = tags.length - maxTags;
     }
   }
 
@@ -39,12 +41,18 @@ const TagCollection = ({ tags, max }) => {
                 onDelete={tag.onDelete ? tag.onDelete : false}
                 key={key(tag.value)}
                 label={tag.value}
-                max={tag.max ? tag.max : 0}
+                maxLength={maxLength}
               />
             );
           }
 
-          return <TagSingle key={key(tag.toString())} label={tag.toString()} />;
+          return (
+            <TagSingle
+              key={key(tag.toString())}
+              label={tag.toString()}
+              maxLength={maxLength}
+            />
+          );
         })
       }
       {spillOver > 0 && <SpillOver>{`+${spillOver}`}</SpillOver>}

--- a/src/Tooltip/Tooltip.stories.js
+++ b/src/Tooltip/Tooltip.stories.js
@@ -3,7 +3,6 @@ import {
   withKnobs,
 } from '@storybook/addon-knobs';
 import * as Tooltip from './index';
-import * as Tag from '../Tag';
 
 const center = {
   height: '100vh', width: '100vw', display: 'flex', justifyContent: 'center', alignItems: 'center',
@@ -20,8 +19,7 @@ export const bottomMiddle = () => (
   <div style={center}>
     <Tooltip.Middle tip={someFormattedToolTip}>
       <div>
-        {/*   <h1 style={{ display: 'inline-block' }}>Hover me</h1> */}
-        <Tag.Collection tags={[1, 2, 3, 4].map((el) => ({ value: 'asdfasdfasdfasdfasdf', maxLength: 5 }))} maxTags={2} maxLength={5} />
+        <h1 style={{ display: 'inline-block' }}>Hover me</h1>
       </div>
     </Tooltip.Middle>
   </div>

--- a/src/Tooltip/Tooltip.stories.js
+++ b/src/Tooltip/Tooltip.stories.js
@@ -3,6 +3,7 @@ import {
   withKnobs,
 } from '@storybook/addon-knobs';
 import * as Tooltip from './index';
+import * as Tag from '../Tag';
 
 const center = {
   height: '100vh', width: '100vw', display: 'flex', justifyContent: 'center', alignItems: 'center',
@@ -18,7 +19,10 @@ Some other text.
 export const bottomMiddle = () => (
   <div style={center}>
     <Tooltip.Middle tip={someFormattedToolTip}>
-      <h1 style={{ display: 'inline-block' }}>Hover me</h1>
+      <div>
+        {/*   <h1 style={{ display: 'inline-block' }}>Hover me</h1> */}
+        <Tag.Collection tags={[1, 2, 3, 4].map((el) => ({ value: 'asdfasdfasdfasdfasdf', maxLength: 5 }))} maxTags={2} maxLength={5} />
+      </div>
     </Tooltip.Middle>
   </div>
 );


### PR DESCRIPTION
# Description

Fix tag overflow, max string length for tags in collections, and renaming of props (both single and collection had a prop named max but meant different things, string length in one and max tags in one -> maxLength, maxTags).
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] Go to http://localhost:6006/?path=/story/ui-components-tag--singe-tag (and the 2 collection ones),  and change the story to have very long strings and resize the window, change the maxLength & maxTags-props  and check that it works as expected

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
