### PR TITLE
Change tooltip-comonent from class to func, and close on children-change

### DIFF
--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -3,13 +3,9 @@ import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 
 import * as C from './Tooltip.styled';
+import { positions, getCoordinates } from './helpers';
 
 const tooltipRoot = document.getElementById('tooltip-root');
-const positions = {
-  middle: 'middle',
-  right: 'right',
-  left: 'left',
-};
 
 const propTypes = {
   children: PropTypes.oneOfType([
@@ -34,20 +30,8 @@ const Tooltip = ({ position, tip, children }) => {
 
   const handleMouseEnter = () => {
     if (ref.current != null) {
-      const {
-        x, top, height, width,
-      } = ref.current.getBoundingClientRect();
-
-      const spacing = 5;
-
-      if (position === positions.right) {
-        setCoordinates({ left: x + width + spacing, top: top + (height / 2) });
-      } else if (position === positions.left) {
-        setCoordinates({ left: x - spacing, top: top + (height / 2) });
-      } else {
-        // Middle
-        setCoordinates({ left: x + (width / 2), top: top + height + spacing });
-      }
+      const coords = getCoordinates({ position, ref });
+      setCoordinates(coords);
       setShow(true);
     }
   };
@@ -73,10 +57,7 @@ const Tooltip = ({ position, tip, children }) => {
       ) }
       { show === true && tip
             && createPortal(
-              <C.TooltipWrapper
-                position={position}
-                style={coordinates}
-              >
+              <C.TooltipWrapper position={position} style={coordinates}>
                 {tip}
               </C.TooltipWrapper>,
               tooltipRoot,

--- a/src/Tooltip/helpers.js
+++ b/src/Tooltip/helpers.js
@@ -1,0 +1,21 @@
+export const positions = {
+  middle: 'middle',
+  right: 'right',
+  left: 'left',
+};
+
+export const getCoordinates = ({ position, ref }) => {
+  const {
+    x, top, height, width,
+  } = ref.current.getBoundingClientRect();
+
+  const spacing = 5;
+
+  if (position === positions.right) {
+    return { left: x + width + spacing, top: top + (height / 2) };
+  } if (position === positions.left) {
+    return { left: x - spacing, top: top + (height / 2) };
+  }
+  // Middle
+  return { left: x + (width / 2), top: top + height + spacing };
+};


### PR DESCRIPTION
# Description

The tooltip can get stuck when something in the children/DOM changes, like for example the button that's supposed to have the tooltip changes position on a click event; example go to http://localhost:3000/service-window?sw_q=w%20sort%3Astart-desc%20%20page%3A1 and expand a service window. Put the cursor on top of the gray circle of the caret-arrow to close it, and it's still there since the mouse is not longer on the button. Auto close the tooltop on children change.

Fixes https://github.com/asurgent/admin/issues/1048

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Easiest to copy it to cloudops-portal and go to http://localhost:3000/service-window?sw_q=w%20sort%3Astart-desc%20%20page%3A1, then expand a service window, close it by clicking at the top of the gray caret button. The tooltip should not show.

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
