### PR TITLE
Render/hide for subnavigation block

### DIFF
--- a/src/Block/Block.stories.js
+++ b/src/Block/Block.stories.js
@@ -137,8 +137,14 @@ export const subnavigationBlock = () => (
         iconStyle: { background: 'pink' },
         navigationStyle: { background: 'magenta' },
         labelStyle: { background: 'orange' },
+        render: () => true,
       },
-      { label: 'Other stuff', path: 'http://apple.com', icon: '' },
+      {
+        label: 'Other stuff', path: 'http://apple.com', icon: '',
+      },
+      {
+        label: 'Hidden stuff', path: 'http://apple.com', icon: '', render: () => false,
+      },
     ]}
   >
     <h2>I am title</h2>

--- a/src/Block/components/SubnavigationBlock/SubnavigationBlock.js
+++ b/src/Block/components/SubnavigationBlock/SubnavigationBlock.js
@@ -22,6 +22,7 @@ const SubnavigationBlock = ({ navigationList, title, children }) => (
     <C.Navigation>
       {
         navigationList.map(({
+          render = () => true,
           path,
           icon,
           label,
@@ -30,11 +31,12 @@ const SubnavigationBlock = ({ navigationList, title, children }) => (
           navigationStyle,
           labelStyle,
         }) => (
+          render() && (
           <C.NavigationItem style={navigationStyle} to={path} key={path} isActive={isActive}>
             <C.Icon style={iconStyle}>{icon}</C.Icon>
             <C.Label style={labelStyle}>{label}</C.Label>
           </C.NavigationItem>
-        ))
+          )))
       }
     </C.Navigation>
     <C.Content>


### PR DESCRIPTION
# Description

Subnavigationblock ignores the renderprop at the moment, fix for that

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Go to http://localhost:6006/?path=/story/ui-components-block--subnavigation-block and change the values in the navigationList-prop in Block.stories.js, if not adding a renderprop at all or giving it a true value, it should render, and not if added a negative value for render.

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
