### PR TITLE
Disabled prop for all formtypes

### DIFF
--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -54,11 +54,6 @@ const ticketValues = {
 
 export const simpleForm = () => {
   const formData = Form.useFormBuilder(formObj);
-  useEffect(() => {
-    const updated = Object.keys(formObj).map((obj) => ({ name: obj, value: 'asdfasdf' }));
-    formData.updateFields(updated);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
   return (
     <Form.Primary
       form={formData}

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -16,7 +16,7 @@ export default {
 
 const formObj = {
   label: {
-    type: 'label', label: 'Test', value: 'Im just a label', disabled: true,
+    type: 'label', label: 'Test', value: 'Im just a label',
   },
   search: {
     type: 'text', label: 'Test', placeholder: 'Hello',
@@ -68,7 +68,7 @@ export const defaultForm = () => {
       type: 'text',
       label: 'Some Text',
       tooltip: 'hejhej',
-      disabled: true,
+      disabled: () => true,
     },
     imABoolean: {
       type: 'bool',
@@ -76,7 +76,7 @@ export const defaultForm = () => {
       tooltipPosition: 'left',
       tooltip: 'Select me',
       value: false,
-      disabled: true,
+      disabled: () => true,
     },
     email: {
       type: 'email',
@@ -111,7 +111,6 @@ export const defaultForm = () => {
       ],
       render: (s) => s.someRadioGroup && s.someRadioGroup === 'value2',
       tooltip: 'tooltip',
-      disabled: true,
     },
     someSelect: {
       type: 'select',

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -16,7 +16,7 @@ export default {
 
 const formObj = {
   label: {
-    type: 'label', label: 'Test', value: 'Im just a label',
+    type: 'label', label: 'Test', value: 'Im just a label', disabled: true,
   },
   search: {
     type: 'text', label: 'Test', placeholder: 'Hello',
@@ -54,7 +54,11 @@ const ticketValues = {
 
 export const simpleForm = () => {
   const formData = Form.useFormBuilder(formObj);
-
+  useEffect(() => {
+    const updated = Object.keys(formObj).map((obj) => ({ name: obj, value: 'asdfasdf' }));
+    formData.updateFields(updated);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return (
     <Form.Primary
       form={formData}
@@ -69,6 +73,7 @@ export const defaultForm = () => {
       type: 'text',
       label: 'Some Text',
       tooltip: 'hejhej',
+      disabled: true,
     },
     imABoolean: {
       type: 'bool',
@@ -76,6 +81,7 @@ export const defaultForm = () => {
       tooltipPosition: 'left',
       tooltip: 'Select me',
       value: false,
+      disabled: true,
     },
     email: {
       type: 'email',
@@ -86,12 +92,14 @@ export const defaultForm = () => {
         errorMessage: 'I did not validate',
       },
       value: '',
+      disabled: true,
     },
     someNumber: {
       type: 'number',
       label: 'Some Number (max 100)',
       tooltip: 'hejhej',
       maxValue: 100,
+      disabled: true,
     },
     someRadioGroup: {
       type: 'radiogroup',
@@ -100,6 +108,7 @@ export const defaultForm = () => {
         { label: 'label1', value: 'value1' },
         { label: 'label2', value: 'value2' },
       ],
+      disabled: true,
     },
     someRadioGroup2: {
       type: 'radiogroup',
@@ -110,6 +119,7 @@ export const defaultForm = () => {
       ],
       render: (s) => s.someRadioGroup && s.someRadioGroup === 'value2',
       tooltip: 'tooltip',
+      disabled: true,
     },
     someSelect: {
       type: 'select',
@@ -121,6 +131,7 @@ export const defaultForm = () => {
       ],
       tooltip: 'tooltip',
       placeholder: 'select',
+      disabled: true,
     },
     someSelect2: {
       type: 'select',
@@ -131,6 +142,7 @@ export const defaultForm = () => {
         { value: '3', label: 'Third option' },
       ],
       tooltip: 'tooltip',
+      disabled: true,
     },
     someFilterSelectSingle: {
       type: 'filterselect',
@@ -141,6 +153,7 @@ export const defaultForm = () => {
         searchPlaceholder: 'Search in me plz',
       },
       placeholder: 'Select me',
+      disabled: true,
     },
     someFilterSelectMulti: {
       type: 'filterselect',
@@ -152,6 +165,7 @@ export const defaultForm = () => {
         multiSelect: true,
         searchPlaceholder: 'Search in me plz',
       },
+      disabled: true,
     },
     someDate: {
       type: 'datepicker',
@@ -159,6 +173,7 @@ export const defaultForm = () => {
       render: (spec) => spec.someText && spec.someText.length < 10,
       tooltip: 'tooltip',
       label: 'Some date',
+      disabled: true,
     },
   });
   const renderErrors = boolean('render errors', false);

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -92,14 +92,12 @@ export const defaultForm = () => {
         errorMessage: 'I did not validate',
       },
       value: '',
-      disabled: true,
     },
     someNumber: {
       type: 'number',
       label: 'Some Number (max 100)',
       tooltip: 'hejhej',
       maxValue: 100,
-      disabled: true,
     },
     someRadioGroup: {
       type: 'radiogroup',
@@ -108,7 +106,6 @@ export const defaultForm = () => {
         { label: 'label1', value: 'value1' },
         { label: 'label2', value: 'value2' },
       ],
-      disabled: true,
     },
     someRadioGroup2: {
       type: 'radiogroup',
@@ -131,7 +128,6 @@ export const defaultForm = () => {
       ],
       tooltip: 'tooltip',
       placeholder: 'select',
-      disabled: true,
     },
     someSelect2: {
       type: 'select',
@@ -142,7 +138,6 @@ export const defaultForm = () => {
         { value: '3', label: 'Third option' },
       ],
       tooltip: 'tooltip',
-      disabled: true,
     },
     someFilterSelectSingle: {
       type: 'filterselect',
@@ -153,7 +148,6 @@ export const defaultForm = () => {
         searchPlaceholder: 'Search in me plz',
       },
       placeholder: 'Select me',
-      disabled: true,
     },
     someFilterSelectMulti: {
       type: 'filterselect',
@@ -165,7 +159,6 @@ export const defaultForm = () => {
         multiSelect: true,
         searchPlaceholder: 'Search in me plz',
       },
-      disabled: true,
     },
     someDate: {
       type: 'datepicker',
@@ -173,7 +166,6 @@ export const defaultForm = () => {
       render: (spec) => spec.someText && spec.someText.length < 10,
       tooltip: 'tooltip',
       label: 'Some date',
-      disabled: true,
     },
   });
   const renderErrors = boolean('render errors', false);
@@ -194,6 +186,7 @@ export const defaultForm = () => {
           '3',
           '4',
         ],
+        value: '3',
       },
       {
         name: 'someFilterSelectMulti',

--- a/src/Form/components/InputWrapper.js
+++ b/src/Form/components/InputWrapper.js
@@ -28,6 +28,7 @@ const propTyps = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -37,6 +38,7 @@ const defaultProps = {
   className: '',
   classNameWrapper: '',
   tooltipPosition: 'middle',
+  disabled: false,
 };
 
 const InputWrapper = (props) => {
@@ -50,6 +52,7 @@ const InputWrapper = (props) => {
     type,
     className,
     classNameWrapper,
+    disabled,
   } = props;
 
   return (
@@ -64,7 +67,7 @@ const InputWrapper = (props) => {
           )}
         </Header>
       )}
-      <Wrapper hasError={Boolean(error)} className={classNameWrapper}>
+      <Wrapper disabled={disabled} hasError={Boolean(error)} className={classNameWrapper}>
         {children}
       </Wrapper>
       {error && (

--- a/src/Form/components/InputWrapper.js
+++ b/src/Form/components/InputWrapper.js
@@ -28,7 +28,7 @@ const propTyps = {
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
@@ -38,7 +38,7 @@ const defaultProps = {
   className: '',
   classNameWrapper: '',
   tooltipPosition: 'middle',
-  disabled: false,
+  disabled: () => false,
 };
 
 const InputWrapper = (props) => {
@@ -67,7 +67,7 @@ const InputWrapper = (props) => {
           )}
         </Header>
       )}
-      <Wrapper disabled={disabled} hasError={Boolean(error)} className={classNameWrapper}>
+      <Wrapper disabled={disabled()} hasError={Boolean(error)} className={classNameWrapper}>
         {children}
       </Wrapper>
       {error && (

--- a/src/Form/components/InputWrapper.styled.js
+++ b/src/Form/components/InputWrapper.styled.js
@@ -74,7 +74,7 @@ export const Wrapper = styled.div`
   }
   * {
     color: ${({ theme, disabled }) => (disabled ? theme.gray400 : theme.black)};
-    cursor: ${(disabled) => (disabled ? 'not-allowed' : 'initial')}
+    cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'initial')}
   }
  
 `;

--- a/src/Form/components/InputWrapper.styled.js
+++ b/src/Form/components/InputWrapper.styled.js
@@ -72,8 +72,11 @@ export const Wrapper = styled.div`
     position:absolute;
     right: .8rem;
   }
-  
-  
+  * {
+    color: ${({ theme, disabled }) => (disabled ? theme.gray400 : theme.black)};
+    cursor: ${(disabled) => (disabled ? 'not-allowed' : 'initial')}
+  }
+ 
 `;
 
 export const Label = styled.div`

--- a/src/Form/hooks/helpers.js
+++ b/src/Form/hooks/helpers.js
@@ -95,6 +95,7 @@ export const generateFieldComponents = (inputs, referenceList, errors, keepInput
         className,
         classNameWrapper,
         props: inputProps,
+        disabled = false,
       } = inputs[key];
 
       let inputValue = value;
@@ -117,6 +118,7 @@ export const generateFieldComponents = (inputs, referenceList, errors, keepInput
           type={type}
           className={className}
           classNameWrapper={classNameWrapper}
+          disabled={disabled}
         >
           <RequestedComponent
             hook={self}

--- a/src/Form/hooks/helpers.js
+++ b/src/Form/hooks/helpers.js
@@ -135,6 +135,7 @@ export const generateFieldComponents = (inputs, referenceList, errors, keepInput
             parseOutput={parseOutput}
             props={inputProps}
             options={options}
+            disabled={disabled}
           />
         </InputWrapper>
       );

--- a/src/Form/hooks/helpers.js
+++ b/src/Form/hooks/helpers.js
@@ -95,7 +95,7 @@ export const generateFieldComponents = (inputs, referenceList, errors, keepInput
         className,
         classNameWrapper,
         props: inputProps,
-        disabled = false,
+        disabled = () => false,
       } = inputs[key];
 
       let inputValue = value;

--- a/src/Form/types/Bool/Bool.js
+++ b/src/Form/types/Bool/Bool.js
@@ -14,16 +14,18 @@ const propTyps = {
   label: PropTypes.string,
   name: PropTypes.string.isRequired,
   props: PropTypes.instanceOf(Object),
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
   value: 'false',
   label: '',
   props: {},
+  disabled: false,
 };
 
 const Bool = forwardRef((props, ref) => {
-  const { name, label } = props;
+  const { name, label, disabled } = props;
   const { t } = translation;
 
   const [value, setValue] = useState();
@@ -47,6 +49,7 @@ const Bool = forwardRef((props, ref) => {
       options={options}
       ref={ref}
       props={props.props}
+      disabled={disabled}
     />
   );
 });

--- a/src/Form/types/Bool/Bool.js
+++ b/src/Form/types/Bool/Bool.js
@@ -14,14 +14,14 @@ const propTyps = {
   label: PropTypes.string,
   name: PropTypes.string.isRequired,
   props: PropTypes.instanceOf(Object),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
   value: 'false',
   label: '',
   props: {},
-  disabled: false,
+  disabled: () => false,
 };
 
 const Bool = forwardRef((props, ref) => {

--- a/src/Form/types/DatePicker/DatePicker.js
+++ b/src/Form/types/DatePicker/DatePicker.js
@@ -24,6 +24,7 @@ const DatePicker = forwardRef((props, ref) => {
     maxDateMessage,
     minDate,
     minDateMessage,
+    disabled,
   } = props;
 
   const input = createRef();
@@ -68,6 +69,7 @@ const DatePicker = forwardRef((props, ref) => {
           KeyboardButtonProps={{
             'aria-label': 'change date',
           }}
+          disabled={disabled}
           {...props.props}
         />
       </MuiPickersUtilsProvider>
@@ -105,6 +107,7 @@ DatePicker.propTypes = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
+  disabled: PropTypes.bool,
 };
 
 DatePicker.defaultProps = {
@@ -123,6 +126,7 @@ DatePicker.defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
+  disabled: false,
 };
 
 DatePicker.displayName = '@asurgent.ui.Form.Input.DatePicker';

--- a/src/Form/types/DatePicker/DatePicker.js
+++ b/src/Form/types/DatePicker/DatePicker.js
@@ -69,7 +69,7 @@ const DatePicker = forwardRef((props, ref) => {
           KeyboardButtonProps={{
             'aria-label': 'change date',
           }}
-          disabled={disabled}
+          disabled={disabled()}
           {...props.props}
         />
       </MuiPickersUtilsProvider>
@@ -107,7 +107,7 @@ DatePicker.propTypes = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 DatePicker.defaultProps = {
@@ -126,7 +126,7 @@ DatePicker.defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
-  disabled: false,
+  disabled: () => false,
 };
 
 DatePicker.displayName = '@asurgent.ui.Form.Input.DatePicker';

--- a/src/Form/types/Email/Email.js
+++ b/src/Form/types/Email/Email.js
@@ -19,6 +19,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -31,6 +32,7 @@ const defaultProps = {
     condition: (v) => emailRegexp.test(v),
     errorMessage: 'Unvalid email format',
   },
+  disabled: false,
 };
 
 const Email = forwardRef((props, ref) => {
@@ -39,6 +41,7 @@ const Email = forwardRef((props, ref) => {
     placeholder,
     parseOutput,
     validator,
+    disabled,
   } = props;
   const input = createRef();
 
@@ -65,6 +68,7 @@ const Email = forwardRef((props, ref) => {
       onChange={({ target }) => setValue(target.value)}
       name={name}
       ref={input}
+      disabled={disabled}
     />
   );
 });

--- a/src/Form/types/Email/Email.js
+++ b/src/Form/types/Email/Email.js
@@ -19,7 +19,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
@@ -32,7 +32,7 @@ const defaultProps = {
     condition: (v) => emailRegexp.test(v),
     errorMessage: 'Unvalid email format',
   },
-  disabled: false,
+  disabled: () => false,
 };
 
 const Email = forwardRef((props, ref) => {
@@ -68,7 +68,7 @@ const Email = forwardRef((props, ref) => {
       onChange={({ target }) => setValue(target.value)}
       name={name}
       ref={input}
-      disabled={disabled}
+      disabled={disabled()}
     />
   );
 });

--- a/src/Form/types/FilterSelect/FilterSelect.js
+++ b/src/Form/types/FilterSelect/FilterSelect.js
@@ -33,6 +33,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -45,6 +46,7 @@ const defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
+  disabled: false,
 };
 
 const dispatchEvent = (value, ref) => {
@@ -65,6 +67,7 @@ const FilterInput = forwardRef((props, ref) => {
     placeholder,
     parseOutput,
     props: inputProps,
+    disabled,
   } = props;
   const placeholdeOutput = placeholder || t('selectPlaceholder', 'asurgentui');
   const searchInput = createRef();
@@ -102,7 +105,7 @@ const FilterInput = forwardRef((props, ref) => {
       shieldIsUp={filterSelectHook.isOpen}
     >
       <C.SelectFilter onClick={() => filterSelectHook.setOpen(true)}>
-        <C.Input type="text" name={name} ref={filterSelectHook.inputRef} disabled {...inputProps} />
+        <C.Input disabled={disabled} type="text" name={name} ref={filterSelectHook.inputRef} disabled {...inputProps} />
         <C.Output>
           <C.Value asPlaceholder={filterSelectHook.showPlaceHolder()}>
             { filterSelectHook.showTags() && (

--- a/src/Form/types/FilterSelect/FilterSelect.js
+++ b/src/Form/types/FilterSelect/FilterSelect.js
@@ -33,7 +33,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
@@ -46,7 +46,7 @@ const defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
-  disabled: false,
+  disabled: () => false,
 };
 
 const dispatchEvent = (value, ref) => {
@@ -104,10 +104,10 @@ const FilterInput = forwardRef((props, ref) => {
       onClick={() => filterSelectHook.setOpen(false)}
       shieldIsUp={filterSelectHook.isOpen}
     >
-      <C.SelectFilter onClick={() => !disabled && filterSelectHook.setOpen(true)}>
+      <C.SelectFilter onClick={() => !disabled() && filterSelectHook.setOpen(true)}>
         <C.Input type="text" name={name} ref={filterSelectHook.inputRef} disabled {...inputProps} />
         <C.Output>
-          <C.Value disabled={disabled} asPlaceholder={filterSelectHook.showPlaceHolder()}>
+          <C.Value disabled={disabled()} asPlaceholder={filterSelectHook.showPlaceHolder()}>
             { filterSelectHook.showTags() && (
               <Tag.Collection tags={filterSelectHook.getTags()} max={3} />
             )}

--- a/src/Form/types/FilterSelect/FilterSelect.js
+++ b/src/Form/types/FilterSelect/FilterSelect.js
@@ -104,10 +104,10 @@ const FilterInput = forwardRef((props, ref) => {
       onClick={() => filterSelectHook.setOpen(false)}
       shieldIsUp={filterSelectHook.isOpen}
     >
-      <C.SelectFilter onClick={() => filterSelectHook.setOpen(true)}>
-        <C.Input disabled={disabled} type="text" name={name} ref={filterSelectHook.inputRef} disabled {...inputProps} />
+      <C.SelectFilter onClick={() => !disabled && filterSelectHook.setOpen(true)}>
+        <C.Input type="text" name={name} ref={filterSelectHook.inputRef} disabled {...inputProps} />
         <C.Output>
-          <C.Value asPlaceholder={filterSelectHook.showPlaceHolder()}>
+          <C.Value disabled={disabled} asPlaceholder={filterSelectHook.showPlaceHolder()}>
             { filterSelectHook.showTags() && (
               <Tag.Collection tags={filterSelectHook.getTags()} max={3} />
             )}

--- a/src/Form/types/FilterSelect/FilterSelect.styled.js
+++ b/src/Form/types/FilterSelect/FilterSelect.styled.js
@@ -28,7 +28,12 @@ export const Value = styled.div`
     padding-right: 2rem;
     overflow: hidden;
     text-overflow: ellipsis;
-    color: ${({ theme, asPlaceholder }) => (asPlaceholder ? theme.gray400 : theme.black)};
+    color: ${({ theme, asPlaceholder, disabled }) => ((asPlaceholder || disabled) ? theme.gray400 : theme.black)};
+    
+    /* Tags */
+    * {
+        color: ${({ theme, disabled }) => (disabled ? theme.gray400 : theme.black)};
+    }
 `;
 
 export const SearchWrapper = styled.div`
@@ -69,7 +74,6 @@ export const Dropdown = styled.div`
     display: flex;
     flex-direction: column;
     
-
     .close {
         position: absolute;
         right: 1.6rem;

--- a/src/Form/types/Number/Number.js
+++ b/src/Form/types/Number/Number.js
@@ -23,6 +23,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -37,6 +38,7 @@ const defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
+  disabled: false,
 };
 
 const NumberInput = forwardRef((props, ref) => {
@@ -47,6 +49,7 @@ const NumberInput = forwardRef((props, ref) => {
     maxValue,
     parseOutput,
     validator,
+    disabled,
   } = props;
   const input = createRef();
   const { hook: form } = useContext(FormContext);
@@ -119,6 +122,7 @@ const NumberInput = forwardRef((props, ref) => {
       }}
       name={name}
       ref={input}
+      disabled={disabled}
     />
   );
 });

--- a/src/Form/types/Number/Number.js
+++ b/src/Form/types/Number/Number.js
@@ -23,7 +23,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
@@ -38,7 +38,7 @@ const defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
-  disabled: false,
+  disabled: () => false,
 };
 
 const NumberInput = forwardRef((props, ref) => {
@@ -122,7 +122,7 @@ const NumberInput = forwardRef((props, ref) => {
       }}
       name={name}
       ref={input}
-      disabled={disabled}
+      disabled={disabled()}
     />
   );
 });

--- a/src/Form/types/RadioGroup/RadioGroup.js
+++ b/src/Form/types/RadioGroup/RadioGroup.js
@@ -15,6 +15,7 @@ const propTypes = {
   wrapRadios: PropTypes.bool,
   parseOutput: PropTypes.func,
   props: PropTypes.instanceOf(Object),
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -23,6 +24,7 @@ const defaultProps = {
   wrapRadios: false,
   props: {},
   parseOutput: (val) => val || '',
+  disabled: false,
 };
 
 const RadioGroup = forwardRef((props, ref) => {
@@ -31,6 +33,7 @@ const RadioGroup = forwardRef((props, ref) => {
     options,
     wrapRadios,
     parseOutput,
+    disabled,
   } = props;
   const [val, setVal] = useState(null);
   const input = createRef();
@@ -57,6 +60,7 @@ const RadioGroup = forwardRef((props, ref) => {
               checked={val === opt.value}
               ref={val === opt.value ? input : null}
               readOnly
+              disabled={disabled}
               {...props.props}
             />
             <C.CheckMark />

--- a/src/Form/types/RadioGroup/RadioGroup.js
+++ b/src/Form/types/RadioGroup/RadioGroup.js
@@ -15,7 +15,7 @@ const propTypes = {
   wrapRadios: PropTypes.bool,
   parseOutput: PropTypes.func,
   props: PropTypes.instanceOf(Object),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
@@ -24,7 +24,7 @@ const defaultProps = {
   wrapRadios: false,
   props: {},
   parseOutput: (val) => val || '',
-  disabled: false,
+  disabled: () => false,
 };
 
 const RadioGroup = forwardRef((props, ref) => {
@@ -60,7 +60,7 @@ const RadioGroup = forwardRef((props, ref) => {
               checked={val === opt.value}
               ref={val === opt.value ? input : null}
               readOnly
-              disabled={disabled}
+              disabled={disabled()}
               {...props.props}
             />
             <C.CheckMark />

--- a/src/Form/types/RadioGroup/RadioGroup.styled.js
+++ b/src/Form/types/RadioGroup/RadioGroup.styled.js
@@ -39,7 +39,7 @@ export const CheckMark = styled.span`
     height: 2rem;
     width: 2rem;
     background-color: #fff;
-    border: 0.2rem solid black ;
+    border: 0.2rem solid black;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -51,20 +51,6 @@ export const CheckMark = styled.span`
         width: 50%;
         height: 50%;
         border-radius: 100%;
-        background: ${({ theme }) => theme.blue900};
-    }
-`;
-
-export const RadioInput = styled.input`
-    width: 2rem!important;
-    height: 2rem!important;   
-    margin: 0; 
-    /* change border color and draw the dot */
-    &:checked + ${CheckMark} {
-    border: ${({ theme }) => `0.2rem solid ${theme.blue900}`};
-        &:after {
-            display: block;
-        }
     }
 `;
 
@@ -73,4 +59,26 @@ export const Text = styled.span`
     line-height: 1.6rem;
     overflow: hidden;
     text-overflow: ellipsis;
+`;
+
+export const RadioInput = styled.input`
+    width: 2rem!important;
+    height: 2rem!important;   
+    margin: 0; 
+    /* change border color and draw the dot */
+    &:checked + ${CheckMark} {
+    border: ${({ theme, disabled }) => `0.2rem solid ${disabled ? theme.gray400 : theme.blue900}`};
+        &:after {
+            display: block;
+        }
+    }
+    ~ ${CheckMark} {
+        border-color: ${({ theme, disabled }) => (disabled ? theme.gray400 : theme.blue900)};
+        &:after {
+            background: ${({ theme, disabled }) => (disabled ? theme.gray400 : theme.blue900)};
+        }
+    }
+    ~ ${Text} {
+        color: ${({ theme, disabled }) => (disabled ? theme.gray400 : theme.black)};
+    }
 `;

--- a/src/Form/types/Select/Select.js
+++ b/src/Form/types/Select/Select.js
@@ -15,6 +15,7 @@ const propTyps = {
   props: PropTypes.instanceOf(Object),
   placeholder: PropTypes.string,
   parseOutput: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -22,6 +23,7 @@ const defaultProps = {
   props: {},
   placeholder: '',
   parseOutput: (v) => v,
+  disabled: false,
 };
 
 const getDefaultSort = (sortKeys) => {
@@ -45,6 +47,7 @@ const Select = forwardRef((props, ref) => {
     options,
     placeholder,
     parseOutput,
+    disabled,
   } = props;
 
   const input = createRef();
@@ -77,6 +80,7 @@ const Select = forwardRef((props, ref) => {
         onChange={({ target }) => setValue(target.value)}
         value={value || ''}
         name={name}
+        disabled={disabled}
       >
         {placeholder && (
         <option disabled value="">
@@ -88,14 +92,14 @@ const Select = forwardRef((props, ref) => {
             value: optionValue,
             label: optionLabel,
             key,
-            disabled,
+            disabledOption,
             disabledPreFix,
             disabledPostFix,
           }) => (
-            <option key={key || `${optionLabel}-${value}`} value={optionValue} disabled={disabled}>
-              {disabled && disabledPreFix}
+            <option key={key || `${optionLabel}-${value}`} value={optionValue} disabled={disabledOption}>
+              {disabledOption && disabledPreFix}
               {optionLabel}
-              {disabled && disabledPostFix}
+              {disabledOption && disabledPostFix}
             </option>
           ))}
       </select>

--- a/src/Form/types/Select/Select.js
+++ b/src/Form/types/Select/Select.js
@@ -15,7 +15,7 @@ const propTyps = {
   props: PropTypes.instanceOf(Object),
   placeholder: PropTypes.string,
   parseOutput: PropTypes.func,
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
@@ -23,7 +23,7 @@ const defaultProps = {
   props: {},
   placeholder: '',
   parseOutput: (v) => v,
-  disabled: false,
+  disabled: () => false,
 };
 
 const getDefaultSort = (sortKeys) => {
@@ -80,7 +80,7 @@ const Select = forwardRef((props, ref) => {
         onChange={({ target }) => setValue(target.value)}
         value={value || ''}
         name={name}
-        disabled={disabled}
+        disabled={disabled()}
       >
         {placeholder && (
         <option disabled value="">

--- a/src/Form/types/Text/Text.js
+++ b/src/Form/types/Text/Text.js
@@ -18,7 +18,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
@@ -31,7 +31,7 @@ const defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
-  disabled: false,
+  disabled: () => false,
 };
 
 const Text = forwardRef((props, ref) => {
@@ -66,7 +66,7 @@ const Text = forwardRef((props, ref) => {
       onChange={({ target }) => setValue(target.value)}
       name={name}
       ref={input}
-      disabled={disabled}
+      disabled={disabled()}
     />
   );
 });

--- a/src/Form/types/Text/Text.js
+++ b/src/Form/types/Text/Text.js
@@ -18,6 +18,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -30,6 +31,7 @@ const defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
+  disabled: false,
 };
 
 const Text = forwardRef((props, ref) => {
@@ -38,6 +40,7 @@ const Text = forwardRef((props, ref) => {
     placeholder,
     parseOutput,
     validator,
+    disabled,
   } = props;
   const input = createRef();
   const [value, setValue] = useState('');
@@ -63,6 +66,7 @@ const Text = forwardRef((props, ref) => {
       onChange={({ target }) => setValue(target.value)}
       name={name}
       ref={input}
+      disabled={disabled}
     />
   );
 });

--- a/src/Form/types/TextArea/TextArea.js
+++ b/src/Form/types/TextArea/TextArea.js
@@ -13,7 +13,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
-  disabled: PropTypes.bool,
+  disabled: PropTypes.func,
 };
 
 const defaultProps = {
@@ -25,7 +25,7 @@ const defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
-  disabled: false,
+  disabled: () => false,
 };
 
 const TextArea = forwardRef((props, ref) => {
@@ -58,7 +58,7 @@ const TextArea = forwardRef((props, ref) => {
       onChange={({ target }) => setValue(target.value)}
       name={name}
       autoComplete="off"
-      disabled={disabled}
+      disabled={disabled()}
     />
   );
 });

--- a/src/Form/types/TextArea/TextArea.js
+++ b/src/Form/types/TextArea/TextArea.js
@@ -13,6 +13,7 @@ const propTyps = {
     condition: PropTypes.func,
     errorMessage: PropTypes.string,
   }),
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -24,6 +25,7 @@ const defaultProps = {
     condition: () => true,
     errorMessage: '',
   },
+  disabled: false,
 };
 
 const TextArea = forwardRef((props, ref) => {
@@ -32,6 +34,7 @@ const TextArea = forwardRef((props, ref) => {
     placeholder,
     parseOutput,
     validator,
+    disabled,
   } = props;
 
   const [value, setValue] = useState('');
@@ -55,6 +58,7 @@ const TextArea = forwardRef((props, ref) => {
       onChange={({ target }) => setValue(target.value)}
       name={name}
       autoComplete="off"
+      disabled={disabled}
     />
   );
 });

--- a/src/List/List.styled.js
+++ b/src/List/List.styled.js
@@ -20,6 +20,7 @@ export const Title = styled.div`
     border-bottom: 1px solid ${({ theme }) => theme.gray300};
     word-break: break-all;
     min-width: 8rem;
+    flex-wrap: wrap;
 `;
 
 export const Value = styled(Title)`


### PR DESCRIPTION
# Description

Add a disabled property for formtypes (color, uneditable and cursor).

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] Go to http://localhost:6006/?path=/story/ui-components-form--default-form and add/remove "disabled: true" in Form.stories.js on the form types and check that they behave as they should. For example
` someNumber: {
      type: 'number',
      ...
    },`
to
 `someNumber: {
      type: 'number',
      ...
      disabled: true
    }`

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
