### PR TITLE
Number type fix & add/remove change event for multiple object form type

### DIFF
--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -348,7 +348,7 @@ export const defaultForm = () => {
               <Button.Secondary disabled={!isDirty} onClick={onResetAction}>
                 Reset
               </Button.Secondary>
-              <Button.Primary onClick={onSubmitAction}>Submit</Button.Primary>
+              <Button.Primary disabled={!isDirty} onClick={onSubmitAction}>Submit</Button.Primary>
             </Block.SpaceBetween>
           </>
         )}

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -87,7 +87,7 @@ export const defaultForm = () => {
         conditions: () => {
           const validation = {
             someName: { valid: (val) => val === 'hej', errorMessage: 'not "hej"' },
-            someNumber: { valid: (val) => val === 1, errorMessage: 'not 1' },
+            someNumber: { valid: (val) => typeof val === 'number' && val === 2, errorMessage: 'not 1' },
           };
           return validation;
         },
@@ -115,6 +115,7 @@ export const defaultForm = () => {
         conditions: () => {
           const validation = {
             someName: { valid: (val) => val === 'hello', errorMessage: 'not "hello"' },
+            someNumber: { valid: (val) => typeof val === 'number', errorMessage: 'not a number' },
           };
           return validation;
         },
@@ -122,6 +123,7 @@ export const defaultForm = () => {
       options: {
         someName: { label: 'translatedMultiLabel1', type: 'string' },
         someOtherName: { label: 'translatedMultiLabel2', type: 'string', render: () => false },
+        someNumber: { label: 'translatedMultiLabel3', type: 'number' },
         someSelect: {
           label: 'translatedMultiLabel3',
           type: 'select',
@@ -131,7 +133,6 @@ export const defaultForm = () => {
             { label: 'someLabel4', value: 'someValue4' },
           ],
         },
-        someNumber: { label: 'translatedMultiLabel4', type: 'number', disabled: () => true },
       },
     },
     email: {

--- a/src/Form/types/ObjectInput/InputWrapper.js
+++ b/src/Form/types/ObjectInput/InputWrapper.js
@@ -1,9 +1,6 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import * as C from './ObjectInput.styled';
-/* import Select from '../Select'; */
-/* import Text from '../Text';
-import Number from '../Number'; */
 
 const propTypes = {
   type: PropTypes.string,
@@ -53,13 +50,6 @@ const InputWrapper = (props) => {
     return null;
   }, [validator, value]);
 
-  const val = useMemo(() => {
-    if (value) {
-      return type === 'number' ? parseInt(value, 10) : value;
-    }
-    return '';
-  }, [type, value]);
-
   if (render()) {
     return (
       <>
@@ -78,7 +68,7 @@ const InputWrapper = (props) => {
             </select>
           ) : (
             <input
-              value={val}
+              value={value || ''}
               name={name}
               type={type}
               onChange={onChange}

--- a/src/Form/types/ObjectInput/Multiple/Multiple.js
+++ b/src/Form/types/ObjectInput/Multiple/Multiple.js
@@ -59,6 +59,15 @@ const Multiple = forwardRef((props, ref) => {
 
   const input = createRef();
 
+  // trigger change event on form on add/remove button-clicks
+  const dispatchEvent = () => {
+    const element = input.current;
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+    nativeInputValueSetter.call(element, value);
+    const inputEvent = new Event('input', { bubbles: true });
+    element.dispatchEvent(inputEvent);
+  };
+
   useImperativeHandle(ref, () => ({
     validationErrorMessage: validator.errorMessage,
     value: () => parseOutput(value),
@@ -85,11 +94,13 @@ const Multiple = forwardRef((props, ref) => {
     const newValue = [...value, newEntry];
     setValue(newValue);
     setNewEntry(clearObjectValues(options));
+    dispatchEvent();
   };
 
   const handleRemove = ({ index }) => {
     const newValue = value.filter((v, ind) => ind !== index);
     setValue(newValue);
+    dispatchEvent();
   };
 
   const canAdd = useMemo(() => valuePassedValidation({

--- a/src/Form/types/ObjectInput/Multiple/Multiple.js
+++ b/src/Form/types/ObjectInput/Multiple/Multiple.js
@@ -60,10 +60,10 @@ const Multiple = forwardRef((props, ref) => {
   const input = createRef();
 
   // trigger change event on form on add/remove button-clicks
-  const dispatchEvent = () => {
+  const dispatchEvent = (newValue) => {
     const element = input.current;
     const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
-    nativeInputValueSetter.call(element, value);
+    nativeInputValueSetter.call(element, newValue);
     const inputEvent = new Event('input', { bubbles: true });
     element.dispatchEvent(inputEvent);
   };
@@ -94,13 +94,13 @@ const Multiple = forwardRef((props, ref) => {
     const newValue = [...value, newEntry];
     setValue(newValue);
     setNewEntry(clearObjectValues(options));
-    dispatchEvent();
+    dispatchEvent(newValue);
   };
 
   const handleRemove = ({ index }) => {
     const newValue = value.filter((v, ind) => ind !== index);
     setValue(newValue);
-    dispatchEvent();
+    dispatchEvent(newValue);
   };
 
   const canAdd = useMemo(() => valuePassedValidation({

--- a/src/Form/types/ObjectInput/Multiple/Multiple.js
+++ b/src/Form/types/ObjectInput/Multiple/Multiple.js
@@ -68,11 +68,17 @@ const Multiple = forwardRef((props, ref) => {
   const handleChange = ({ target, index }) => {
     const newArr = value.map((ent, ind) => {
       if (ind === index) {
-        return { ...ent, [target.name]: target.value };
+        const val = target.type === 'number' ? parseInt(target.value, 10) : target.value;
+        return { ...ent, [target.name]: val };
       }
       return ent;
     });
     setValue(newArr);
+  };
+
+  const handleChangeNewEntry = ({ target, key }) => {
+    const val = options[key].type === 'number' ? parseInt(target.value, 10) : target.value;
+    setNewEntry({ ...newEntry, [key]: val });
   };
 
   const handleAdd = () => {
@@ -154,7 +160,7 @@ const Multiple = forwardRef((props, ref) => {
                 label={options[key].label}
                 value={newEntry[key]}
                 type={options[key].type}
-                onChange={({ target }) => setNewEntry({ ...newEntry, [key]: target.value })}
+                onChange={({ target }) => handleChangeNewEntry({ target, key })}
                 disabled={options[key].disabled}
                 render={options[key].render}
                 options={options[key].options}

--- a/src/Form/types/ObjectInput/Single/Single.js
+++ b/src/Form/types/ObjectInput/Single/Single.js
@@ -56,7 +56,8 @@ const Single = forwardRef((props, ref) => {
   }));
 
   const handleChange = ({ target }) => {
-    const newValue = { ...value, [target.name]: target.value };
+    const val = target.type === 'number' ? parseInt(target.value, 10) : target.value;
+    const newValue = { ...value, [target.name]: val };
     setValue(newValue);
   };
 
@@ -75,7 +76,6 @@ const Single = forwardRef((props, ref) => {
         {Object.keys(value).map((key, index) => {
           const option = options[key];
           const entryValidator = validator?.conditions()[key];
-
           return (
             <InputWrapper
               /* eslint-disable-next-line react/no-array-index-key */


### PR DESCRIPTION
# Description

Numbers on object input was treated as a string, and add/remove changes didnt register on button clicks (had to do a change a field after the button clicks for the form to register as dirty).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] In Form.stories remove all fields except for the object multiple-type and go to http://localhost:6006/?path=/story/ui-components-form--default-form and add/remove an entry, you should be able to submit the form.

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
