### PR TITLE
Background "invisible" filter applied to all other filters & mock story

### DIFF
--- a/src/Table/TableFilter/useFilterGroupHook.js
+++ b/src/Table/TableFilter/useFilterGroupHook.js
@@ -139,9 +139,18 @@ const useFilterProvider = (tableHook, filterHook, filterGroupKey) => {
       // Ommit the targetd group from the selected-items object and generate
       // a request-string that excludes the targeted group
       const { [filterGroupKey]: current, ...rest } = filterHook.getSelectedItems();
-      const requestString = buildFilterQuery(rest);
-
-      tableHook.loadFilterForKey(filterGroupKey, requestString);
+      const filter = buildFilterQuery(rest);
+      const parser = filterHook.getParser();
+      if (parser.requestString && typeof parser.requestString === 'function') {
+        const requestString = parser.requestString(filter);
+        if (typeof requestString === 'string') {
+          tableHook.loadFilterForKey(filterGroupKey, requestString);
+        } else {
+          tableHook.loadFilterForKey(filterGroupKey, filter);
+        }
+      } else {
+        tableHook.loadFilterForKey(filterGroupKey, filter);
+      }
       setIsReady(true);
     } else {
       setSearch('');

--- a/src/Table/TableFilter/useFilterHook.js
+++ b/src/Table/TableFilter/useFilterHook.js
@@ -98,7 +98,7 @@ const useFilterProvider = (filterKeys, tableHook, parser) => {
       // Look if there is items in the selected group
       // But dont include if its not a multiselect (aka singleSelect) filter.
       // Since a singleSelect MUST have a value, it cant be cleared.
-      return (list.length > 0) && category.multiSelect !== false;
+      return (list.length > 0) && category?.multiSelect !== false;
     });
 
     setHasSelectedItems(hasSelected);


### PR DESCRIPTION
# Description

When on an entity - service windows for example - the service window list can be filtered by entity_id initially, but that filters doesnt apply to the other filters in the table. So for example requested_by shows for all service windows, not just the one with the specific entity_id. Fix for that

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] A mock setup can be found on http://localhost:6006/?path=/story/ui-components-table--main-searchable, but proably better to do "npm run copy" and go to http://localhost:3000/my-environment/3688/CBE12C108BC497FF8686A51E8F556F95C577F027/service-windows to test it out.

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
