### PR TITLE
Tojo table padding fix

### DIFF
--- a/src/Button/Button.styled.js
+++ b/src/Button/Button.styled.js
@@ -124,9 +124,9 @@ export const Plain = styled.div`
 export const Filter = styled(Button)`
     padding: .8rem;
     background-color: transparent;
-    border-color: transparent;
+    border-color: ${({ theme }) => theme.gray100};
     position: relative;
-    transition: 0.03s;
+    transition: 0.05s;
 
     button {
         cursor: pointer;

--- a/src/Table/BaseTable/BaseTable.styled.js
+++ b/src/Table/BaseTable/BaseTable.styled.js
@@ -32,11 +32,12 @@ export const Count = styled.div`
     align-items: center;
     justify-content: flex-start;
     flex-direction: row;
-    padding: .8rem 0 2.4rem 0;
+    padding: .8rem 2.4rem 2.4rem;
     
     ${Plain} {
       width: 10rem;
       font-size: 1.2rem;
+      white-space: nowrap;
     
       .label {
         display: flex;
@@ -90,6 +91,7 @@ export const Row = styled.div`
   display: grid;
   width: fit-content;
   min-width: 100%;
+  padding: 0 2.4rem;
   grid-column-gap: 0.8rem;
   grid-template-columns: ${({ headerList, equalSize }) => {
     const columnSize = 'minmax(50px, 1fr)';


### PR DESCRIPTION
# Description

Expanded table to the edge with a padding so the hover state won't look cut off anymore. Added back borders on filter dropdown buttons in omnibar to make it look less busy when having a table inside an entity (Like tickets for at specific entity)

Fixes asurgent/admin#1152 (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Author checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
