### PR TITLE
fix for initial setting of values on formtypes

### DIFF
--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -76,7 +76,13 @@ export const defaultForm = () => {
       type: 'text',
       label: 'Some Text',
       tooltip: 'hejhej',
-      disabled: () => true,
+      value: 'text text',
+    },
+    someTextArea: {
+      type: 'textarea',
+      label: 'Some Text',
+      tooltip: 'hejhej',
+      value: 'text area text',
     },
     someTextMultiple: {
       type: 'textmultiple',
@@ -84,6 +90,7 @@ export const defaultForm = () => {
       tooltip: 'hejhej',
       parseOutput: (r) => r.filter((entry) => entry !== ''),
       placeholder: 'Add something cool',
+      value: ['first', 'second'],
     },
     someObject: {
       type: 'objectsingle',
@@ -113,6 +120,7 @@ export const defaultForm = () => {
         },
         someNumber: { label: 'translatedLabel4', type: 'number', render: () => true },
       },
+      value: {},
     },
     someObjectMultiple: {
       type: 'objectmultiple',
@@ -129,8 +137,8 @@ export const defaultForm = () => {
         },
       },
       options: {
-        someName: { label: 'translatedMultiLabel1', type: 'string' },
-        someOtherName: { label: 'translatedMultiLabel2', type: 'string', render: () => false },
+        someName: { label: 'must be "hello" to add', type: 'string' },
+        someOtherName: { label: 'translatedMultiLabel2', type: 'string', render: () => true },
         someNumber: { label: 'translatedMultiLabel3', type: 'number' },
         someSelect: {
           label: 'translatedMultiLabel3',
@@ -142,6 +150,12 @@ export const defaultForm = () => {
           ],
         },
       },
+      value: [{
+        someName: 'someName',
+        someNumber: 23,
+        someOtherName: 'someOtherName',
+        someSelect: 'someValue3',
+      }],
     },
     email: {
       type: 'email',
@@ -151,21 +165,22 @@ export const defaultForm = () => {
         condition: (v) => v === 'asdf',
         errorMessage: 'I did not validate',
       },
-      value: '',
+      value: 'my@email.com',
     },
     imABoolean: {
       type: 'bool',
       label: 'Im true or false',
       tooltipPosition: 'left',
       tooltip: 'Select me',
-      value: false,
-      disabled: () => true,
+      value: true,
+      disabled: () => false,
     },
     someNumber: {
       type: 'number',
       label: 'Some Number (max 100)',
       tooltip: 'hejhej',
       maxValue: 100,
+      value: 50,
     },
     someRadioGroup: {
       type: 'radiogroup',
@@ -174,6 +189,7 @@ export const defaultForm = () => {
         { label: 'label1', value: 'value1' },
         { label: 'label2', value: 'value2' },
       ],
+      value: 'value2',
     },
     someRadioGroup2: {
       type: 'radiogroup',
@@ -184,17 +200,20 @@ export const defaultForm = () => {
       ],
       render: (s) => s.someRadioGroup && s.someRadioGroup === 'value2',
       tooltip: 'tooltip',
+      value: 'value3',
     },
     someSelect: {
       type: 'select',
       label: 'Select with empty option',
+      placeholder: 'select me',
       options: [
         { value: '1', label: 'First option' },
         { value: '2', label: 'Second option' },
         { value: '3', label: 'Third option' },
       ],
+      props: {},
       tooltip: 'tooltip',
-      placeholder: 'select',
+      value: '2', // no value -> shows placeholder
     },
     someSelect2: {
       type: 'select',
@@ -205,27 +224,40 @@ export const defaultForm = () => {
         { value: '3', label: 'Third option' },
       ],
       tooltip: 'tooltip',
+      value: '3', // no value -> sets first option
     },
     someFilterSelectSingle: {
       type: 'filterselect',
       label: 'Some Filterselect (single)',
-      options: [],
       tooltip: 'tooltip',
       props: {
         searchPlaceholder: 'Search in me plz',
       },
       placeholder: 'Select me',
+      options: [
+        { value: '1', label: 'one' },
+        { value: '2', label: 'two' },
+        '3',
+        '4',
+      ],
+      value: '3',
     },
     someFilterSelectMulti: {
       type: 'filterselect',
       label: 'Some Filterselect (multi)',
-      options: [],
       tooltip: 'tooltip',
       parseOutput: (r) => r.join(','),
       props: {
         multiSelect: true,
         searchPlaceholder: 'Search in me plz',
       },
+      options: [
+        { value: '1', label: 'one' },
+        { value: '2', label: 'two' },
+        '3',
+        '4',
+      ],
+      value: ['3', '4'],
     },
     someDate: {
       type: 'datepicker',
@@ -233,73 +265,10 @@ export const defaultForm = () => {
       render: (spec) => spec.someText && spec.someText.length < 10,
       tooltip: 'tooltip',
       label: 'Some date',
+      value: '2020-12-24',
     },
   });
   const renderErrors = boolean('render errors', false);
-
-  useEffect(() => {
-    formData.updateFields([
-      { name: 'someText', value: 'Good bye' },
-      { name: 'someTextMultiple', value: ['Good', 'bye'] },
-      {
-        name: 'someObject',
-        value: {
-          someName: 'hello',
-          someOtherName: 'goodbye',
-          someNumber: 1,
-          someSelect: 'someValue2',
-        },
-      },
-      { name: 'email', value: 'mail@asdf.se' },
-      {
-        name: 'someObjectMultiple',
-        value: [{
-          someName: 'goodbye',
-          someOtherName: 'whats up',
-          someNumber: 1,
-          someSelect: 'someValue3',
-        },
-        {
-          someName: 'hello',
-          someOtherName: 'cya',
-          someNumber: 3,
-          someSelect: 'someValue4',
-        }],
-      },
-      { name: 'someNumber', value: 10 },
-      { name: 'someRadioGroup', value: 'value1' },
-      { name: 'someRadioGroup2', value: 'value4' },
-      { name: 'someSelect', value: '' },
-      { name: 'someSelect2', options: [{ value: '6', label: 'six' }, { value: '7', label: 'seven' }] },
-      {
-        name: 'someFilterSelectSingle',
-        options: [
-          { value: '1', label: 'one' },
-          { value: '2', label: 'two' },
-          '3',
-          '4',
-        ],
-        value: '3',
-      },
-      {
-        name: 'someFilterSelectMulti',
-        value: ['1 First option First option First option First option', '0 Zero option', '2 Second option'],
-        options: [
-          '2 Second option',
-          '3 Third option',
-          '4 Fourth option',
-          '5 Fifth option',
-          '6 Sixth option',
-          '7 Seventh option',
-          '8 Eigth option',
-          '9 Ninth option',
-          '10 Tenth option',
-        ],
-      },
-      { name: 'someDate', value: moment().startOf('day').toISOString() },
-    ]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     if (renderErrors) {

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -142,7 +142,7 @@ export const defaultForm = () => {
       label: 'Im true or false',
       tooltipPosition: 'left',
       tooltip: 'Select me',
-      value: true,
+      value: false,
       disabled: () => false,
     },
     someNumber: {

--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -92,36 +92,6 @@ export const defaultForm = () => {
       placeholder: 'Add something cool',
       value: ['first', 'second'],
     },
-    someObject: {
-      type: 'objectsingle',
-      label: 'Some Object',
-      tooltip: 'hejhej',
-      className: 'asdf',
-      showContainerError: false,
-      validator: {
-        conditions: () => {
-          const validation = {
-            someName: { valid: (val) => val === 'hej', errorMessage: 'not "hej"' },
-            someNumber: { valid: (val) => typeof val === 'number' && val === 2, errorMessage: 'not 1' },
-          };
-          return validation;
-        },
-      },
-      options: {
-        someName: { label: 'translatedLabel1', type: 'string' },
-        someOtherName: { label: 'translatedLabel2', type: 'string', disabled: () => true },
-        someSelect: {
-          label: 'translatedLabel3',
-          type: 'select',
-          placeholder: 'select',
-          options: [
-            { label: 'someLabel1', value: 'someValue1' },
-            { label: 'someLabel2', value: 'someValue2' }],
-        },
-        someNumber: { label: 'translatedLabel4', type: 'number', render: () => true },
-      },
-      value: {},
-    },
     someObjectMultiple: {
       type: 'objectmultiple',
       label: null,

--- a/src/Form/types/Bool/Bool.js
+++ b/src/Form/types/Bool/Bool.js
@@ -28,7 +28,7 @@ const Bool = forwardRef((props, ref) => {
   const { name, label, disabled } = props;
   const { t } = translation;
 
-  const [value, setValue] = useState();
+  const [value, setValue] = useState(`${!!props.value || false}`);
   const parser = useCallback((val) => (val === 'true'), []);
 
   const options = useMemo(() => [

--- a/src/Form/types/Bool/Bool.js
+++ b/src/Form/types/Bool/Bool.js
@@ -28,7 +28,7 @@ const Bool = forwardRef((props, ref) => {
   const { name, label, disabled } = props;
   const { t } = translation;
 
-  const [value, setValue] = useState(`${!!props.value || false}`);
+  const [value, setValue] = useState(`${props.value}`);
   const parser = useCallback((val) => (val === 'true'), []);
 
   const options = useMemo(() => [

--- a/src/Form/types/Email/Email.js
+++ b/src/Form/types/Email/Email.js
@@ -45,7 +45,7 @@ const Email = forwardRef((props, ref) => {
   } = props;
   const input = createRef();
 
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(props.value || '');
 
   useImperativeHandle(ref, () => ({
     value: () => parseOutput(value),

--- a/src/Form/types/RadioGroup/RadioGroup.js
+++ b/src/Form/types/RadioGroup/RadioGroup.js
@@ -35,7 +35,7 @@ const RadioGroup = forwardRef((props, ref) => {
     parseOutput,
     disabled,
   } = props;
-  const [val, setVal] = useState(null);
+  const [val, setVal] = useState(props.value || null);
   const input = createRef();
 
   useEffect(() => {

--- a/src/Form/types/Select/Select.js
+++ b/src/Form/types/Select/Select.js
@@ -51,7 +51,7 @@ const Select = forwardRef((props, ref) => {
   } = props;
 
   const input = createRef();
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(props.value || '');
 
   useImperativeHandle(ref, () => ({
     value: () => parseOutput(value),
@@ -65,8 +65,9 @@ const Select = forwardRef((props, ref) => {
   }, [props.value, props.options]);
 
   useEffect(() => {
-    // only set default value if doesn't have empty option
-    if (!placeholder) {
+    // only set "default value" if it doesnt have a inital prop-value AND
+    // not uses a placeholder like 'Select me'
+    if (!placeholder && !props.value) {
       setValue(getDefaultSort(options));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Form/types/Text/Text.js
+++ b/src/Form/types/Text/Text.js
@@ -43,7 +43,7 @@ const Text = forwardRef((props, ref) => {
     disabled,
   } = props;
   const input = createRef();
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(props.value || '');
 
   useImperativeHandle(ref, () => ({
     value: () => parseOutput(value),

--- a/src/Form/types/TextArea/TextArea.js
+++ b/src/Form/types/TextArea/TextArea.js
@@ -37,7 +37,7 @@ const TextArea = forwardRef((props, ref) => {
     disabled,
   } = props;
 
-  const [value, setValue] = useState('');
+  const [value, setValue] = useState(props.value || '');
 
   useEffect(() => {
     setValue(props.value || '');

--- a/src/Form/types/TextMultiple/TextMultiple.js
+++ b/src/Form/types/TextMultiple/TextMultiple.js
@@ -36,7 +36,7 @@ const TextMultiple = forwardRef((props, ref) => {
     validator,
   } = props;
 
-  const [value, setValue] = useState([]);
+  const [value, setValue] = useState(props.value || []);
   const [newEntry, setNewEntry] = useState('');
 
   useEffect(() => {


### PR DESCRIPTION
# Description

When setting initial values with `Form.useFormBuilder({.... value: myValue` instead of adding it later in `useEffect(() => {
    formData.updateFields([` some form types doesnt register the initial value because of `const [value, setValue] = useState('');` instead of `const [value, setValue] = useState(props.value || '');` . A fix for that

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Go to http://localhost:6006/?path=/story/ui-components-form--default-form and add/remove values in Form.stories.js at line 73 `export const defaultForm = () => {
  const formData = Form.useFormBuilder({`. The form should work as expected

# Author checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
