### PR TITLE
Default select correct select-option

### DIFF
--- a/src/Form/types/Select/Select.js
+++ b/src/Form/types/Select/Select.js
@@ -26,15 +26,15 @@ const defaultProps = {
   disabled: () => false,
 };
 
-const getDefaultSort = (sortKeys) => {
-  if (Array.isArray(sortKeys) && sortKeys.length > 0) {
-    const sort = sortKeys.find(({ default: sortByDefault }) => sortByDefault);
+const getDefaultValue = (options) => {
+  if (Array.isArray(options) && options.length > 0) {
+    const defaultOption = options.find(({ default: isDefault }) => isDefault);
 
-    if (sort) {
-      return sort.value;
+    if (defaultOption) {
+      return defaultOption.value;
     }
 
-    const first = sortKeys[0];
+    const first = options.find((option) => !option.disabledOption);
     return first.value;
   }
 
@@ -68,7 +68,7 @@ const Select = forwardRef((props, ref) => {
     // only set "default value" if it doesnt have a inital prop-value AND
     // not uses a placeholder like 'Select me'
     if (!placeholder && !props.value) {
-      setValue(getDefaultSort(options));
+      setValue(getDefaultValue(options));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
# Description

Don't set a disabled option as selected in a select if there is no value set.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Provide a optionslist with at least 2 options to a select-input. With the first option disabled. The select should not be provided any value.
- When you run the saga the SECOND option should be selected, not the first one, since its disabled.