### PR TITLE
button has clearLocationState but table passes passLocationState

### DIFF
--- a/src/Block/components/SubnavigationBlock/SubnavigationBlock.js
+++ b/src/Block/components/SubnavigationBlock/SubnavigationBlock.js
@@ -40,6 +40,7 @@ const NavGroup = ({ page }) => {
     isActive,
     navigationStyle,
     labelStyle,
+    clearLocationState = false,
   } = page;
 
   return (
@@ -48,6 +49,7 @@ const NavGroup = ({ page }) => {
       isActive={isActive}
       style={navigationStyle}
       renderContentWithoutWrapper
+      clearLocationState={clearLocationState}
     >
       <C.Label style={labelStyle}>{label}</C.Label>
     </NavigationItem>

--- a/src/Table/BaseTable/helpers.js
+++ b/src/Table/BaseTable/helpers.js
@@ -156,13 +156,15 @@ const generateRows = (props, components) => props.rowData
       if (props.clickRowConfigutation) {
         const clickRow = props.clickRowConfigutation(rowData);
         if (typeof clickRow === 'object') {
-          const { link, onClick, passLocationState = false } = clickRow;
+          const {
+            link, onClick, clearLocationState = false,
+          } = clickRow;
           const linkRow = (
             <Button.Plain
               key={rowData.id}
               link={link}
               onClick={onClick}
-              passLocationState={passLocationState}
+              clearLocationState={clearLocationState}
             >
               {row}
             </Button.Plain>


### PR DESCRIPTION
# Description

Button has a prop called clearLocationState, but the table passes passLocationState, so it's never used. Added availiability to use clearLocationState on subnavigation menu too.
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- [ ] copy to portal project and follow https://github.com/asurgent/cloudops-portal/pull/188

# Author checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
