### PR TITLE
Ability to set and override state-keys for tables

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -31,6 +31,7 @@ const propTyps = {
   tooltip: PropTypes.string,
   className: PropTypes.string,
   clearStateKeys: PropTypes.instanceOf(Array),
+  setTableState: PropTypes.instanceOf(Object),
   history: PropTypes.instanceOf(Object).isRequired,
   theme: PropTypes.instanceOf(Object).isRequired,
   renderStyle: PropTypes.instanceOf(Object).isRequired,
@@ -55,6 +56,7 @@ const defaultProps = {
   tooltip: null,
   className: '',
   clearStateKeys: [],
+  setTableState: {},
   type: '',
   tooltipOrientation: 'middle',
   style: {},
@@ -125,6 +127,7 @@ const Button = (props) => {
     style,
     renderStyle: Component,
     renderContentWithoutWrapper,
+    setTableState,
   } = props;
 
   const location = useLocation();
@@ -144,7 +147,7 @@ const Button = (props) => {
 
       if (isInteralLink(link)) {
         event.preventDefault();
-        const search = cleanUpSearchString(clearStateKeys, location);
+        const search = cleanUpSearchString(clearStateKeys, setTableState, location);
 
         history.push(`${link}${search}`);
       }
@@ -205,7 +208,7 @@ const Button = (props) => {
     const Link = Component.withComponent(NavLink);
     const upddatedAttrs = { ...attrs };
 
-    const search = cleanUpSearchString(clearStateKeys, location);
+    const search = cleanUpSearchString(clearStateKeys, setTableState, location);
     Object.assign(upddatedAttrs, {
       to: `${link}${search}`,
     });

--- a/src/Button/Button.stories.js
+++ b/src/Button/Button.stories.js
@@ -16,6 +16,24 @@ export const saveToFileButton = () => (
     <Button.Icon saveToFilename="another_file" tooltip="Saves from object" saveToFile={() => ['a', 'b']} icon={<Icon.ConfirmationNumber fontSize="large" onClick={(e) => action('Clicked!')(e)} />} />
   </>
 );
+
+export const setTableState = () => {
+  const state = {
+    search: 'asd',
+    sort: 'timestamp-asc',
+    page: 1,
+    filter: {
+      timestamp: [['2121-12-12', 'eq']],
+    },
+  };
+
+  return (
+    <Button.Primary link="/123/12" setTableState={{ key: state }}>
+      Test link
+    </Button.Primary>
+  );
+};
+
 export const iconButton = () => (
   <Button.Icon tooltip="Hello" saveLinkState link="/test" icon={<Icon.ConfirmationNumber fontSize="large" onClick={(e) => action('Clicked!')(e)} />} />
 );

--- a/src/Table/TableFilter/components/TableFilter.js
+++ b/src/Table/TableFilter/components/TableFilter.js
@@ -46,7 +46,7 @@ const TableFilter = ({ filterHook, tableHook, className }) => (
     </C.Filters>
     {filterHook.hasActiveFilter() && (
       <Button.Plain onClick={() => filterHook.clearFilter()} disabled={tableHook.isLoading}>
-        <Icons.HighlightOff fontSize="16" />
+        <Icons.HighlightOff />
         {` ${t('clear', 'asurgentui')}`}
       </Button.Plain>
     )}


### PR DESCRIPTION
# Description

setTableState prop for buttons that will override a state-key in the URL with a new encoded table-state value

```
const state = {
    search: 'asd',
    sort: 'timestamp-asc',
    page: 1,
    filter: {
      timestamp: [['2121-12-12', 'eq']],
    },
  };

  return (
    <Button.Primary link="/123/12" setTableState={{ key: state }}>
      Test link
    </Button.Primary>
  );

```
will produce a button with the HREF

`http://localhost:6006/123/12?key=asd%20sort%3Atimestamp-asc%20page%3A1%20filter%3AeyJ0aW1lc3RhbXAiOltbIjIxMjEtMTItMTIiLCJlcSJdXX0%3D`

And set the following state in the table

<img width="1486" alt="Screenshot 2021-01-15 at 12 07 56" src="https://user-images.githubusercontent.com/2223196/104717883-51599380-572a-11eb-83b6-d43759bbde36.png">


## Type of change

- [X] New feature (non-breaking change which adds functionality)
