### PR TITLE
Use requestAnimationFrame on resizeObserver to avoid errors

### DIFF
--- a/src/Graph/components/Canvas/useChartDimensions.js
+++ b/src/Graph/components/Canvas/useChartDimensions.js
@@ -55,18 +55,21 @@ export const useChartDimensions = (customDimensions) => {
     const element = ref.current;
     const resizeObserver = new ResizeObserver(
       (entries) => {
-        if (!Array.isArray(entries)) return;
-        if (!entries.length) return;
-        const entry = entries[0];
+        // Wrap it in requestAnimationFrame to avoid "ResizeObserver loop limit exceeded"
+        // which means that ResizeObserver was not able to deliver all
+        // observations within a single animation frame
+        window.requestAnimationFrame(() => {
+          if (!Array.isArray(entries)) return;
+          if (!entries.length) return;
+          const entry = entries[0];
 
-        if (!dimensions.width
-          && width !== entry.contentRect.width) {
-          setWidth(entry.contentRect.width);
-        }
-        if (!dimensions.height
-          && height !== entry.contentRect.height) {
-          setHeight(entry.contentRect.height);
-        }
+          if (!dimensions.width && width !== entry.contentRect.width) {
+            setWidth(entry.contentRect.width);
+          }
+          if (!dimensions.height && height !== entry.contentRect.height) {
+            setHeight(entry.contentRect.height);
+          }
+        });
       },
     );
     resizeObserver.observe(element);

--- a/src/Table/TableFilter/components/TableFilter.styled.js
+++ b/src/Table/TableFilter/components/TableFilter.styled.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import * as Button from '../../../Button/Button.styled';
 
 export const Wrapper = styled.div`
-    z-index: 1;
     display: grid;
     grid-template-columns: 1fr auto;
     grid-column-gap: 0;


### PR DESCRIPTION
# Description

We get "ResizeObserver - loop limit exceeded" errors on sentry. 
"This error means that ResizeObserver was not able to deliver all observations within a single animation frame". By wrapping it in requestAnimationFrame you can limit the executions to a single frame"  - https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
