### PR TITLE
Option to show results without export button

### DIFF
--- a/src/Table/BaseTable/BaseTable.js
+++ b/src/Table/BaseTable/BaseTable.js
@@ -143,8 +143,9 @@ const BaseTable = withTheme((props) => {
     <C.Wrapper>
       <C.Base>
         <C.ActionMenu>
-          { displayCount && (
+
           <C.Count>
+            {displayCount && (`${itemCount} ${t('results', 'asurgentui')}`)}
             { canExportResults && exportResultsAction && (
               <Button.Plain
                 disabled={itemCount === 0}
@@ -152,12 +153,11 @@ const BaseTable = withTheme((props) => {
                 tooltip={t('export', 'asurgentui')}
                 saveToFile={exportResultsAction}
               >
-                {`${itemCount} ${t('results', 'asurgentui')}`}
                 <C.DownloadBtn path={mdiDownload} />
               </Button.Plain>
             )}
           </C.Count>
-          )}
+
           {onAddRemove && (
             <>
               <C.SelectedNumber bold>

--- a/src/Table/BaseTable/BaseTable.styled.js
+++ b/src/Table/BaseTable/BaseTable.styled.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import { lighten } from 'polished';
 import MdiIcon from '@mdi/react';
-import { Plain } from '../../Button/Button.styled';
 import * as Button from '../../Button';
 import * as T from '../../Typography';
 

--- a/src/Table/BaseTable/BaseTable.styled.js
+++ b/src/Table/BaseTable/BaseTable.styled.js
@@ -33,21 +33,11 @@ export const Count = styled.div`
     align-items: center;
     justify-content: flex-start;
     flex-direction: row;
-    
-    ${Plain} {
-      width: 10rem;
-      font-size: 1.4rem;
-      white-space: nowrap;
-    
-      .label {
-        display: flex;
-        align-content: center;
-        color: ${({ theme }) => theme.gray600};
-      
-        svg {
-          margin-left: .8rem;
-        }
-      }
+    width: 10rem;
+    white-space: nowrap;
+    color: ${({ theme }) => theme.gray600}; 
+    svg {
+      margin-left: .8rem;
     }
 `;
 

--- a/src/Table/Table.stories.js
+++ b/src/Table/Table.stories.js
@@ -419,6 +419,8 @@ const SeparateTemplate = (args) => {
         withControlls={false}
         historyStatePrefix="tickets"
         tableHook={hook}
+        displayCount
+        canExportResults
         clickRowConfigutation={(row) => clicker(row)}
         headerData={[
           {


### PR DESCRIPTION
# Description

Fixes https://github.com/asurgent/admin/issues/1199

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [ ] flip the displayCount and  canExportResults to true/false on the Separate-story in Table.stories.js, should work as expected

# Author checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
