### PR TITLE
Heatmap sizing bug if no legend

### DIFF
--- a/src/Graph/Heatmap/Heatmap.js
+++ b/src/Graph/Heatmap/Heatmap.js
@@ -77,7 +77,6 @@ const Heatmap = ({
   showLegend,
   theme,
 }) => {
-  console.log('showLegend', showLegend);
   const monthTextRef = useRef(null);
   const groupRef = useRef(null);
   const svgRef = createRef(null);

--- a/src/Graph/Heatmap/Heatmap.js
+++ b/src/Graph/Heatmap/Heatmap.js
@@ -77,6 +77,7 @@ const Heatmap = ({
   showLegend,
   theme,
 }) => {
+  console.log('showLegend', showLegend);
   const monthTextRef = useRef(null);
   const groupRef = useRef(null);
   const svgRef = createRef(null);
@@ -137,7 +138,7 @@ const Heatmap = ({
 
   const monthHeight = 20;
   const legendHeight = cellSize + 15; // 15 => text height
-  const svgHeight = ((cellSize + cellGap) * 7) + monthHeight + legendHeight;
+  const svgHeight = ((cellSize + cellGap) * 7) + monthHeight + (showLegend() ? legendHeight : 0);
 
   const reduceToObject = (arr) => arr.reduce((acc, cur) => ({ ...acc, [cur.date]: cur.value }), {});
 


### PR DESCRIPTION
# Description

Don't add height of legend to total SVG-height if legend is not used

Related to: https://github.com/asurgent/cloudops-portal/pull/244

Fixes https://github.com/asurgent/admin/issues/1330

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

