### PR TITLE
vertical radiogroup

### DIFF
--- a/src/Form/Form.stories.js
+++ b/src/Form/Form.stories.js
@@ -169,8 +169,11 @@ const DefaultTemplate = (args) => {
       options: [
         { label: 'label1', value: 'value1' },
         { label: 'label2', value: 'value2' },
+        { label: 'label3', value: 'value3' },
+        { label: 'label4', value: 'value4' },
       ],
       value: 'value2',
+      props: { vertical: true },
     },
     someRadioGroup2: {
       type: 'radiogroup',

--- a/src/Form/types/RadioGroup/RadioGroup.js
+++ b/src/Form/types/RadioGroup/RadioGroup.js
@@ -12,7 +12,6 @@ const propTypes = {
   value: PropTypes.string,
   name: PropTypes.string.isRequired,
   options: PropTypes.arrayOf(PropTypes.instanceOf(Object)),
-  wrapRadios: PropTypes.bool,
   parseOutput: PropTypes.func,
   props: PropTypes.instanceOf(Object),
   disabled: PropTypes.func,
@@ -21,7 +20,6 @@ const propTypes = {
 const defaultProps = {
   value: '',
   options: [],
-  wrapRadios: false,
   props: {},
   parseOutput: (val) => val || '',
   disabled: () => false,
@@ -31,7 +29,6 @@ const RadioGroup = forwardRef((props, ref) => {
   const {
     name,
     options,
-    wrapRadios,
     parseOutput,
     disabled,
   } = props;
@@ -50,7 +47,7 @@ const RadioGroup = forwardRef((props, ref) => {
 
   return (
     <C.FieldSet onChange={({ target }) => setVal(target.value)}>
-      <C.RadioWrapper wrapRadios={wrapRadios}>
+      <C.RadioWrapper wrapRadios={props?.props?.vertical}>
         {options.map((opt) => (
           <C.Label key={opt.label || opt.value}>
             <C.RadioInput

--- a/src/Form/types/RadioGroup/RadioGroup.styled.js
+++ b/src/Form/types/RadioGroup/RadioGroup.styled.js
@@ -16,9 +16,10 @@ export const Label = styled.label`
 
 export const RadioWrapper = styled.div`
     display: flex;
-    flex-direction: ${({ wrapRadios }) => (wrapRadios === true ? 'column' : 'row')};
+    flex-direction: ${({ vertical }) => (vertical === true ? 'column' : 'row')};
     align-items: flex-start;
     flex-wrap: wrap;
+    gap: 1.6rem;
 
     ${Label} {
         margin-right: 1.6rem;


### PR DESCRIPTION
# Description

Vertical radiogroup (old one had prop for it, but didn't work), and added some gap between the radios.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] http://localhost:6006/?path=/story/data-form--default, then change the vertical prop in `   someRadioGroup: {
      type: 'radiogroup',
      label: 'Some Radio Group',
      options: [
        { label: 'label1', value: 'value1' },
        { label: 'label2', value: 'value2' },
        { label: 'label3', value: 'value3' },
        { label: 'label4', value: 'value4' },
      ],
      value: 'value2',
      props: { vertical: true },
    },` in Form.stories
- [ ] Test B

# Author checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have implmented the changes/component in Storybook

# Reviewer checklist:

- [ ] The code runs without errors and/or warnings
- [ ] The code followsthe style guidelines of this project
- [ ] The documentation is sufficinent 
- [ ] The tests runs withour errors and covers all/most states/scenarios
- [ ] The component/changes are represented in storybook
